### PR TITLE
Add OS interface and fake implementation.

### DIFF
--- a/pkg/os/os.go
+++ b/pkg/os/os.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package os
+
+import (
+	"os"
+)
+
+// OS collects system level operations that need to be mocked out
+// during tests.
+type OS interface {
+	MkdirAll(path string, perm os.FileMode) error
+	RemoveAll(path string) error
+}
+
+// RealOS is used to dispatch the real system level operations.
+type RealOS struct{}
+
+// MkdirAll will will call os.MkdirAll to create a directory.
+func (RealOS) MkdirAll(path string, perm os.FileMode) error {
+	return os.MkdirAll(path, perm)
+}
+
+// RemoveAll will call os.RemoveAll to remove the path and its children.
+func (RealOS) RemoveAll(path string) error {
+	return os.RemoveAll(path)
+}

--- a/pkg/os/testing/fake_os.go
+++ b/pkg/os/testing/fake_os.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"os"
+
+	osInterface "github.com/kubernetes-incubator/cri-containerd/pkg/os"
+)
+
+// FakeOS mocks out certain OS calls to avoid perturbing the filesystem
+// If a member of the form `*Fn` is set, that function will be called in place
+// of the real call.
+type FakeOS struct {
+	MkdirAllFn  func(string, os.FileMode) error
+	RemoveAllFn func(string) error
+}
+
+var _ osInterface.OS = &FakeOS{}
+
+// NewFakeOS creates a FakeOS.
+func NewFakeOS() *FakeOS {
+	return &FakeOS{}
+}
+
+// MkdirAll is a fake call that invokes MkdirAllFn or just returns nil.
+func (f *FakeOS) MkdirAll(path string, perm os.FileMode) error {
+	if f.MkdirAllFn != nil {
+		return f.MkdirAllFn(path, perm)
+	}
+	return nil
+}
+
+// RemoveAll is a fake call that invokes RemoveAllFn or just returns nil.
+func (f *FakeOS) RemoveAll(path string) error {
+	if f.RemoveAllFn != nil {
+		return f.RemoveAllFn(path)
+	}
+	return nil
+}


### PR DESCRIPTION
Fixes https://github.com/kubernetes-incubator/cri-containerd/issues/24.

Just a very small PR adding the OS interface for unit testing. So far, I mainly used `MkdirAll` and `RemoveAll` in the sandbox and container lifecycle PRs. So only added those 2 functions for now. We could always extend in the future.

I'm not using mockgen because the code generated could not pass lint...

Signed-off-by: Random-Liu <lantaol@google.com>