### PR TITLE
Return not exist error in metadata store

### DIFF
--- a/pkg/metadata/image_metadata.go
+++ b/pkg/metadata/image_metadata.go
@@ -108,11 +108,6 @@ func (s *imageMetadataStore) Get(digest string) (*ImageMetadata, error) {
 	if err != nil {
 		return nil, err
 	}
-	// Return nil without error if the corresponding metadata
-	// does not exist.
-	if data == nil {
-		return nil, nil
-	}
 	imageMetadata := &ImageMetadata{}
 	if err := json.Unmarshal(data, imageMetadata); err != nil {
 		return nil, err

--- a/pkg/metadata/image_metadata_test.go
+++ b/pkg/metadata/image_metadata_test.go
@@ -80,8 +80,8 @@ func TestImageMetadataStore(t *testing.T) {
 	assert.NoError(err)
 	assert.Len(imgs, 2)
 
-	t.Logf("get should return nil without error after deletion")
+	t.Logf("get should return nil not exist error after deletion")
 	meta, err := s.Get(testID)
-	assert.NoError(err)
+	assert.Error(store.ErrNotExist, err)
 	assert.Nil(meta)
 }

--- a/pkg/metadata/sandbox.go
+++ b/pkg/metadata/sandbox.go
@@ -115,11 +115,6 @@ func (s *sandboxStore) Get(sandboxID string) (*SandboxMetadata, error) {
 	if err != nil {
 		return nil, err
 	}
-	// Return nil without error if the corresponding metadata
-	// does not exist.
-	if data == nil {
-		return nil, nil
-	}
 	sandbox := &SandboxMetadata{}
 	if err := json.Unmarshal(data, sandbox); err != nil {
 		return nil, err

--- a/pkg/metadata/sandbox_test.go
+++ b/pkg/metadata/sandbox_test.go
@@ -113,8 +113,8 @@ func TestSandboxStore(t *testing.T) {
 	assert.NoError(err)
 	assert.Len(sbs, 2)
 
-	t.Logf("get should return nil without error after deletion")
+	t.Logf("get should return nil with not exist error after deletion")
 	meta, err := s.Get(testID)
-	assert.NoError(err)
+	assert.Error(store.ErrNotExist, err)
 	assert.Nil(meta)
 }

--- a/pkg/metadata/util.go
+++ b/pkg/metadata/util.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metadata
+
+import "github.com/kubernetes-incubator/cri-containerd/pkg/metadata/store"
+
+// IsNotExistError is a helper function to check whether the error returned
+// by metadata store is not exist error.
+func IsNotExistError(err error) bool {
+	return err.Error() == store.ErrNotExist.Error()
+}

--- a/pkg/metadata/util_test.go
+++ b/pkg/metadata/util_test.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metadata
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kubernetes-incubator/cri-containerd/pkg/metadata/store"
+)
+
+func TestIsNotExistError(t *testing.T) {
+	err := store.ErrNotExist
+	assert.True(t, IsNotExistError(err))
+	err = errors.New(store.ErrNotExist.Error())
+	assert.True(t, IsNotExistError(err))
+	err = errors.New("random error")
+	assert.False(t, IsNotExistError(err))
+}

--- a/pkg/server/helpers_test.go
+++ b/pkg/server/helpers_test.go
@@ -35,25 +35,34 @@ func TestGetSandbox(t *testing.T) {
 	assert.NoError(t, c.sandboxIDIndex.Add(testID))
 
 	for desc, test := range map[string]struct {
-		id       string
-		expected *metadata.SandboxMetadata
+		id        string
+		expected  *metadata.SandboxMetadata
+		expectErr bool
 	}{
 		"full id": {
-			id:       testID,
-			expected: &testSandbox,
+			id:        testID,
+			expected:  &testSandbox,
+			expectErr: false,
 		},
 		"partial id": {
-			id:       testID[:3],
-			expected: &testSandbox,
+			id:        testID[:3],
+			expected:  &testSandbox,
+			expectErr: false,
 		},
 		"non-exist id": {
-			id:       "gfedcba",
-			expected: nil,
+			id:        "gfedcba",
+			expected:  nil,
+			expectErr: true,
 		},
 	} {
 		t.Logf("TestCase %q", desc)
 		sb, err := c.getSandbox(test.id)
-		assert.NoError(t, err)
+		if test.expectErr {
+			assert.Error(t, err)
+			assert.True(t, metadata.IsNotExistError(err))
+		} else {
+			assert.NoError(t, err)
+		}
 		assert.Equal(t, test.expected, sb)
 	}
 }

--- a/pkg/server/sandbox_remove.go
+++ b/pkg/server/sandbox_remove.go
@@ -25,6 +25,8 @@ import (
 	"github.com/containerd/containerd/api/services/execution"
 
 	"k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/runtime"
+
+	"github.com/kubernetes-incubator/cri-containerd/pkg/metadata"
 )
 
 // RemovePodSandbox removes the sandbox. If there are running containers in the
@@ -39,9 +41,10 @@ func (c *criContainerdService) RemovePodSandbox(ctx context.Context, r *runtime.
 
 	sandbox, err := c.getSandbox(r.GetPodSandboxId())
 	if err != nil {
-		return nil, fmt.Errorf("failed to find sandbox %q: %v", r.GetPodSandboxId(), err)
-	}
-	if sandbox == nil {
+		if !metadata.IsNotExistError(err) {
+			return nil, fmt.Errorf("an error occurred when try to find sandbox %q: %v",
+				r.GetPodSandboxId(), err)
+		}
 		// Do not return error if the id doesn't exist.
 		glog.V(5).Infof("RemovePodSandbox called for sandbox %q that does not exist",
 			r.GetPodSandboxId())

--- a/pkg/server/sandbox_remove_test.go
+++ b/pkg/server/sandbox_remove_test.go
@@ -111,7 +111,8 @@ func TestRemovePodSandbox(t *testing.T) {
 		_, err = c.sandboxIDIndex.Get(testID)
 		assert.Error(t, err, "sandbox id should be removed")
 		meta, err := c.sandboxStore.Get(testID)
-		assert.NoError(t, err)
+		assert.Error(t, err)
+		assert.True(t, metadata.IsNotExistError(err))
 		assert.Nil(t, meta, "sandbox metadata should be removed")
 		res, err = c.RemovePodSandbox(context.Background(), &runtime.RemovePodSandboxRequest{
 			PodSandboxId: testID,

--- a/pkg/server/sandbox_status.go
+++ b/pkg/server/sandbox_status.go
@@ -41,10 +41,8 @@ func (c *criContainerdService) PodSandboxStatus(ctx context.Context, r *runtime.
 
 	sandbox, err := c.getSandbox(r.GetPodSandboxId())
 	if err != nil {
-		return nil, fmt.Errorf("failed to find sandbox %q: %v", r.GetPodSandboxId(), err)
-	}
-	if sandbox == nil {
-		return nil, fmt.Errorf("sandbox %q does not exist", r.GetPodSandboxId())
+		return nil, fmt.Errorf("an error occurred when try to find sandbox %q: %v",
+			r.GetPodSandboxId(), err)
 	}
 	// Use the full sandbox id.
 	id := sandbox.ID

--- a/pkg/server/sandbox_stop.go
+++ b/pkg/server/sandbox_stop.go
@@ -39,10 +39,8 @@ func (c *criContainerdService) StopPodSandbox(ctx context.Context, r *runtime.St
 
 	sandbox, err := c.getSandbox(r.GetPodSandboxId())
 	if err != nil {
-		return nil, fmt.Errorf("failed to find sandbox %q: %v", r.GetPodSandboxId(), err)
-	}
-	if sandbox == nil {
-		return nil, fmt.Errorf("sandbox %q does not exist", r.GetPodSandboxId())
+		return nil, fmt.Errorf("an error occurred when try to find sandbox %q: %v",
+			r.GetPodSandboxId(), err)
 	}
 	// Use the full sandbox id.
 	id := sandbox.ID


### PR DESCRIPTION
Let metadata store return not exist error instead of `nil, nil`.

We made this change to:
1) Make it more convenient and intuitive to use the metadata store;
2) We need the not exist error for `Update` function in container lifecycle management.