### PR TITLE
Apply sandbox image config

### DIFF
--- a/pkg/server/events.go
+++ b/pkg/server/events.go
@@ -49,6 +49,7 @@ func (c *criContainerdService) startEventMonitor() error {
 func (c *criContainerdService) handleEventStream(events execution.ContainerService_EventsClient) {
 	// TODO(random-liu): [P1] Should backoff on this error, or else this will
 	// cause a busy loop.
+	// TODO(random-liu): Handle io.EOF.
 	e, err := events.Recv()
 	if err != nil {
 		glog.Errorf("Failed to receive event: %v", err)

--- a/pkg/server/sandbox_remove.go
+++ b/pkg/server/sandbox_remove.go
@@ -35,7 +35,7 @@ func (c *criContainerdService) RemovePodSandbox(ctx context.Context, r *runtime.
 	glog.V(2).Infof("RemovePodSandbox for sandbox %q", r.GetPodSandboxId())
 	defer func() {
 		if retErr == nil {
-			glog.V(2).Info("RemovePodSandbox %q returns successfully", r.GetPodSandboxId())
+			glog.V(2).Infof("RemovePodSandbox %q returns successfully", r.GetPodSandboxId())
 		}
 	}()
 
@@ -65,6 +65,7 @@ func (c *criContainerdService) RemovePodSandbox(ctx context.Context, r *runtime.
 		return nil, fmt.Errorf("sandbox container %q is not fully stopped", id)
 	}
 
+	// TODO(random-liu): [P0] Cleanup snapshot after switching to new snapshot api.
 	// TODO(random-liu): [P0] Cleanup shm created in RunPodSandbox.
 	// TODO(random-liu): [P1] Remove permanent namespace once used.
 

--- a/pkg/server/sandbox_stop.go
+++ b/pkg/server/sandbox_stop.go
@@ -34,7 +34,7 @@ func (c *criContainerdService) StopPodSandbox(ctx context.Context, r *runtime.St
 	glog.V(2).Infof("StopPodSandbox for sandbox %q", r.GetPodSandboxId())
 	defer func() {
 		if retErr == nil {
-			glog.V(2).Info("StopPodSandbox %q returns successfully", r.GetPodSandboxId())
+			glog.V(2).Infof("StopPodSandbox %q returns successfully", r.GetPodSandboxId())
 		}
 	}()
 
@@ -56,7 +56,7 @@ func (c *criContainerdService) StopPodSandbox(ctx context.Context, r *runtime.St
 	} else if !os.IsNotExist(err) { // It's ok for sandbox.NetNS to *not* exist
 		return nil, fmt.Errorf("failed to stat netns path for sandbox %q before tearing down the network: %v", id, err)
 	}
-	glog.V(2).Info("TearDown network for sandbox %q successfully", id)
+	glog.V(2).Infof("TearDown network for sandbox %q successfully", id)
 
 	// TODO(random-liu): [P1] Handle sandbox container graceful deletion.
 	// Delete the sandbox container from containerd.

--- a/pkg/server/service.go
+++ b/pkg/server/service.go
@@ -65,6 +65,9 @@ type criContainerdService struct {
 	os osinterface.OS
 	// rootDir is the directory for managing cri-containerd files.
 	rootDir string
+	// sandboxImage is the image to use for sandbox container.
+	// TODO(random-liu): Make this configurable via flag.
+	sandboxImage string
 	// sandboxStore stores all sandbox metadata.
 	sandboxStore metadata.SandboxStore
 	// imageMetadataStore stores all image metadata.
@@ -100,6 +103,7 @@ func NewCRIContainerdService(conn *grpc.ClientConn, rootDir, networkPluginBinDir
 	c := &criContainerdService{
 		os:                 osinterface.RealOS{},
 		rootDir:            rootDir,
+		sandboxImage:       defaultSandboxImage,
 		sandboxStore:       metadata.NewSandboxStore(store.NewMetadataStore()),
 		containerStore:     metadata.NewContainerStore(store.NewMetadataStore()),
 		imageMetadataStore: metadata.NewImageMetadataStore(store.NewMetadataStore()),

--- a/pkg/server/testing/fake_rootfs_client.go
+++ b/pkg/server/testing/fake_rootfs_client.go
@@ -169,7 +169,11 @@ func (f *FakeRootfsClient) Prepare(ctx context.Context, prepareOpts *rootfs.Prep
 	if ok {
 		return nil, fmt.Errorf("mounts already exist")
 	}
-	f.MountList[prepareOpts.Name] = []*mount.Mount{}
+	f.MountList[prepareOpts.Name] = []*mount.Mount{{
+		Type:   "bind",
+		Source: prepareOpts.Name,
+		// TODO(random-liu): Fake options based on Readonly option.
+	}}
 	return &rootfs.MountResponse{
 		Mounts: f.MountList[prepareOpts.Name],
 	}, nil


### PR DESCRIPTION
Based on https://github.com/kubernetes-incubator/cri-containerd/pull/41 and https://github.com/kubernetes-incubator/cri-containerd/pull/46.

This PR let sandbox container use pause image and applies image config.

Only the last commit is new. Will rebase the PR and previous PRs soon.