### PR TITLE
Generate and maintain resolv.conf for sandbox

### DIFF
--- a/pkg/os/os.go
+++ b/pkg/os/os.go
@@ -18,6 +18,7 @@ package os
 
 import (
 	"io"
+	"io/ioutil"
 	"os"
 
 	"golang.org/x/net/context"
@@ -33,6 +34,7 @@ type OS interface {
 	OpenFifo(ctx context.Context, fn string, flag int, perm os.FileMode) (io.ReadWriteCloser, error)
 	Stat(name string) (os.FileInfo, error)
 	CopyFile(src, dest string, perm os.FileMode) error
+	WriteFile(filename string, data []byte, perm os.FileMode) error
 }
 
 // RealOS is used to dispatch the real system level operations.
@@ -74,4 +76,9 @@ func (RealOS) CopyFile(src, dest string, perm os.FileMode) error {
 
 	_, err = io.Copy(out, in)
 	return err
+}
+
+// WriteFile will call ioutil.WriteFile to write data into a file.
+func (RealOS) WriteFile(filename string, data []byte, perm os.FileMode) error {
+	return ioutil.WriteFile(filename, data, perm)
 }

--- a/pkg/os/testing/fake_os.go
+++ b/pkg/os/testing/fake_os.go
@@ -36,6 +36,7 @@ type FakeOS struct {
 	OpenFifoFn  func(context.Context, string, int, os.FileMode) (io.ReadWriteCloser, error)
 	StatFn      func(string) (os.FileInfo, error)
 	CopyFileFn  func(string, string, os.FileMode) error
+	WriteFileFn func(string, []byte, os.FileMode) error
 	errors      map[string]error
 }
 
@@ -139,6 +140,18 @@ func (f *FakeOS) CopyFile(src, dest string, perm os.FileMode) error {
 
 	if f.CopyFileFn != nil {
 		return f.CopyFileFn(src, dest, perm)
+	}
+	return nil
+}
+
+// WriteFile is a fake call that invokes WriteFileFn or just return nil.
+func (f *FakeOS) WriteFile(filename string, data []byte, perm os.FileMode) error {
+	if err := f.getError("WriteFile"); err != nil {
+		return err
+	}
+
+	if f.WriteFileFn != nil {
+		return f.WriteFileFn(filename, data, perm)
 	}
 	return nil
 }

--- a/pkg/server/container_start.go
+++ b/pkg/server/container_start.go
@@ -292,10 +292,6 @@ func (c *criContainerdService) generateContainerSpec(id string, sandboxPid uint3
 
 	// TODO(random-liu): [P2] Add apparmor and seccomp.
 
-	// TODO(random-liu): [P1] Bind mount sandbox /dev/shm.
-
-	// TODO(random-liu): [P0] Bind mount sandbox resolv.conf.
-
 	return g.Spec(), nil
 }
 
@@ -307,9 +303,17 @@ func (c *criContainerdService) generateContainerMounts(sandboxRootDir string, co
 	mounts = append(mounts, &runtime.Mount{
 		ContainerPath: etcHosts,
 		HostPath:      getSandboxHosts(sandboxRootDir),
-		Readonly:      securityContext.ReadonlyRootfs,
+		Readonly:      securityContext.GetReadonlyRootfs(),
 	})
-	// TODO(random-liu): [P0] Mount sandbox resolv.config.
+
+	// Mount sandbox resolv.config.
+	// TODO: Need to figure out whether we should always mount it as read-only
+	mounts = append(mounts, &runtime.Mount{
+		ContainerPath: resolvConfPath,
+		HostPath:      getResolvPath(sandboxRootDir),
+		Readonly:      securityContext.GetReadonlyRootfs(),
+	})
+
 	// TODO(random-liu): [P0] Mount sandbox /dev/shm.
 	return mounts
 }

--- a/pkg/server/container_start_test.go
+++ b/pkg/server/container_start_test.go
@@ -173,22 +173,24 @@ func getStartContainerTestData() (*runtime.ContainerConfig, *runtime.PodSandboxC
 
 func TestGeneralContainerSpec(t *testing.T) {
 	testID := "test-id"
+	testPodID := "test-pod-id"
 	testPid := uint32(1234)
 	config, sandboxConfig, imageConfig, specCheck := getStartContainerTestData()
 	c := newTestCRIContainerdService()
-	spec, err := c.generateContainerSpec(testID, testPid, config, sandboxConfig, imageConfig, nil)
+	spec, err := c.generateContainerSpec(testID, testPodID, testPid, config, sandboxConfig, imageConfig, nil)
 	assert.NoError(t, err)
 	specCheck(t, testID, testPid, spec)
 }
 
 func TestContainerSpecTty(t *testing.T) {
 	testID := "test-id"
+	testPodID := "test-pod-id"
 	testPid := uint32(1234)
 	config, sandboxConfig, imageConfig, specCheck := getStartContainerTestData()
 	c := newTestCRIContainerdService()
 	for _, tty := range []bool{true, false} {
 		config.Tty = tty
-		spec, err := c.generateContainerSpec(testID, testPid, config, sandboxConfig, imageConfig, nil)
+		spec, err := c.generateContainerSpec(testID, testPodID, testPid, config, sandboxConfig, imageConfig, nil)
 		assert.NoError(t, err)
 		specCheck(t, testID, testPid, spec)
 		assert.Equal(t, tty, spec.Process.Terminal)
@@ -197,12 +199,13 @@ func TestContainerSpecTty(t *testing.T) {
 
 func TestContainerSpecReadonlyRootfs(t *testing.T) {
 	testID := "test-id"
+	testPodID := "test-pod-id"
 	testPid := uint32(1234)
 	config, sandboxConfig, imageConfig, specCheck := getStartContainerTestData()
 	c := newTestCRIContainerdService()
 	for _, readonly := range []bool{true, false} {
 		config.Linux.SecurityContext.ReadonlyRootfs = readonly
-		spec, err := c.generateContainerSpec(testID, testPid, config, sandboxConfig, imageConfig, nil)
+		spec, err := c.generateContainerSpec(testID, testPodID, testPid, config, sandboxConfig, imageConfig, nil)
 		assert.NoError(t, err)
 		specCheck(t, testID, testPid, spec)
 		assert.Equal(t, readonly, spec.Root.Readonly)
@@ -211,6 +214,7 @@ func TestContainerSpecReadonlyRootfs(t *testing.T) {
 
 func TestContainerSpecWithExtraMounts(t *testing.T) {
 	testID := "test-id"
+	testPodID := "test-pod-id"
 	testPid := uint32(1234)
 	config, sandboxConfig, imageConfig, specCheck := getStartContainerTestData()
 	c := newTestCRIContainerdService()
@@ -225,7 +229,7 @@ func TestContainerSpecWithExtraMounts(t *testing.T) {
 		HostPath:      "test-host-path-extra",
 		Readonly:      true,
 	}
-	spec, err := c.generateContainerSpec(testID, testPid, config, sandboxConfig, imageConfig, []*runtime.Mount{extraMount})
+	spec, err := c.generateContainerSpec(testID, testPodID, testPid, config, sandboxConfig, imageConfig, []*runtime.Mount{extraMount})
 	assert.NoError(t, err)
 	specCheck(t, testID, testPid, spec)
 	var mounts []runtimespec.Mount

--- a/pkg/server/helpers.go
+++ b/pkg/server/helpers.go
@@ -69,6 +69,9 @@ const (
 	sandboxesDir = "sandboxes"
 	// containersDir contains all container root.
 	containersDir = "containers"
+	// According to http://man7.org/linux/man-pages/man5/resolv.conf.5.html:
+	// "The search list is currently limited to six domains with a total of 256 characters."
+	maxDNSSearches = 6
 	// stdinNamedPipe is the name of stdin named pipe.
 	stdinNamedPipe = "stdin"
 	// stdoutNamedPipe is the name of stdout named pipe.
@@ -87,6 +90,8 @@ const (
 	pidNSFormat = "/proc/%v/ns/pid"
 	// etcHosts is the default path of /etc/hosts file.
 	etcHosts = "/etc/hosts"
+	// resolvConfPath is the abs path of resolv.conf on host or container.
+	resolvConfPath = "/etc/resolv.conf"
 )
 
 // generateID generates a random unique id.
@@ -147,6 +152,11 @@ func getStreamingPipes(rootDir string) (string, string, string) {
 // getSandboxHosts returns the hosts file path inside the sandbox root directory.
 func getSandboxHosts(sandboxRootDir string) string {
 	return filepath.Join(sandboxRootDir, "hosts")
+}
+
+// getResolvPath returns resolv.conf filepath for specified sandbox.
+func getResolvPath(sandboxRoot string) string {
+	return filepath.Join(sandboxRoot, "resolv.conf")
 }
 
 // prepareStreamingPipes prepares stream named pipe for container. returns nil

--- a/pkg/server/sandbox_run_test.go
+++ b/pkg/server/sandbox_run_test.go
@@ -270,5 +270,48 @@ func TestRunPodSandbox(t *testing.T) {
 	assert.Equal(t, expectedPluginArgument, pluginArgument, "SetUpPod should be called with correct arguments")
 }
 
+func TestParseDNSOption(t *testing.T) {
+	for desc, test := range map[string]struct {
+		servers         []string
+		searches        []string
+		options         []string
+		expectedContent string
+		expectErr       bool
+	}{
+		"empty dns options should return empty content": {},
+		"non-empty dns options should return correct content": {
+			servers:  []string{"8.8.8.8", "server.google.com"},
+			searches: []string{"114.114.114.114"},
+			options:  []string{"timeout:1"},
+			expectedContent: `search 114.114.114.114
+nameserver 8.8.8.8
+nameserver server.google.com
+options timeout:1
+`,
+		},
+		"should return error if dns search exceeds limit(6)": {
+			searches: []string{
+				"server0.google.com",
+				"server1.google.com",
+				"server2.google.com",
+				"server3.google.com",
+				"server4.google.com",
+				"server5.google.com",
+				"server6.google.com",
+			},
+			expectErr: true,
+		},
+	} {
+		t.Logf("TestCase %q", desc)
+		resolvContent, err := parseDNSOptions(test.servers, test.searches, test.options)
+		if test.expectErr {
+			assert.Error(t, err)
+			continue
+		}
+		assert.NoError(t, err)
+		assert.Equal(t, resolvContent, test.expectedContent)
+	}
+}
+
 // TODO(random-liu): [P1] Add unit test for different error cases to make sure
 // the function cleans up on error properly.

--- a/pkg/server/sandbox_run_test.go
+++ b/pkg/server/sandbox_run_test.go
@@ -161,6 +161,7 @@ func TestSetupSandboxFiles(t *testing.T) {
 	testRootDir := "test-sandbox-root"
 	expectedCopys := [][]interface{}{
 		{"/etc/hosts", testRootDir + "/hosts", os.FileMode(0666)},
+		{"/etc/resolv.conf", testRootDir + "/resolv.conf", os.FileMode(0644)},
 	}
 	c := newTestCRIContainerdService()
 	var copys [][]interface{}
@@ -169,7 +170,7 @@ func TestSetupSandboxFiles(t *testing.T) {
 		return nil
 	}
 	c.setupSandboxFiles(testRootDir, nil)
-	assert.Equal(t, expectedCopys, copys, "should copy /etc/hosts for sandbox")
+	assert.Equal(t, expectedCopys, copys, "should copy expected files for sandbox")
 }
 
 func TestRunPodSandbox(t *testing.T) {


### PR DESCRIPTION
This is implement part of #28, I'll continue to write some related unit test for this.
> And we may need to maintain it for hostNetwork pod, let me double check it and rely later.

@Random-Liu I copy a host resolv.conf for each pod with hostNetwork, since user may change this file in container. Let me know if you change your mind.

Signed-off-by: Crazykev <crazykev@zju.edu.cn>