### PR TITLE
Remove golang 1.7 from ci.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: go
 go:
-    - 1.7.x
     - 1.8.x
     - tip
 


### PR DESCRIPTION
Both containerd and kubernetes dropped the support for golang 1.7.

Remove golang 1.7.

Signed-off-by: Lantao Liu <lantaol@google.com>

/cc @mikebrow 