### PR TITLE
Add sandbox /etc/hosts.

### DIFF
--- a/pkg/os/os.go
+++ b/pkg/os/os.go
@@ -32,6 +32,7 @@ type OS interface {
 	RemoveAll(path string) error
 	OpenFifo(ctx context.Context, fn string, flag int, perm os.FileMode) (io.ReadWriteCloser, error)
 	Stat(name string) (os.FileInfo, error)
+	CopyFile(src, dest string, perm os.FileMode) error
 }
 
 // RealOS is used to dispatch the real system level operations.
@@ -55,4 +56,22 @@ func (RealOS) OpenFifo(ctx context.Context, fn string, flag int, perm os.FileMod
 // Stat will call os.Stat to get the status of the given file.
 func (RealOS) Stat(name string) (os.FileInfo, error) {
 	return os.Stat(name)
+}
+
+// CopyFile copys src file to dest file
+func (RealOS) CopyFile(src, dest string, perm os.FileMode) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	out, err := os.OpenFile(dest, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	_, err = io.Copy(out, in)
+	return err
 }

--- a/pkg/os/testing/fake_os.go
+++ b/pkg/os/testing/fake_os.go
@@ -34,7 +34,8 @@ type FakeOS struct {
 	MkdirAllFn  func(string, os.FileMode) error
 	RemoveAllFn func(string) error
 	OpenFifoFn  func(context.Context, string, int, os.FileMode) (io.ReadWriteCloser, error)
-	StatFn      func(name string) (os.FileInfo, error)
+	StatFn      func(string) (os.FileInfo, error)
+	CopyFileFn  func(string, string, os.FileMode) error
 	errors      map[string]error
 }
 
@@ -118,7 +119,7 @@ func (f *FakeOS) OpenFifo(ctx context.Context, fn string, flag int, perm os.File
 	return nil, nil
 }
 
-// Stat is a fake call that invokes Stat or just return nil.
+// Stat is a fake call that invokes StatFn or just return nil.
 func (f *FakeOS) Stat(name string) (os.FileInfo, error) {
 	if err := f.getError("Stat"); err != nil {
 		return nil, err
@@ -128,4 +129,16 @@ func (f *FakeOS) Stat(name string) (os.FileInfo, error) {
 		return f.StatFn(name)
 	}
 	return nil, nil
+}
+
+// CopyFile is a fake call that invokes CopyFileFn or just return nil.
+func (f *FakeOS) CopyFile(src, dest string, perm os.FileMode) error {
+	if err := f.getError("CopyFile"); err != nil {
+		return err
+	}
+
+	if f.CopyFileFn != nil {
+		return f.CopyFileFn(src, dest, perm)
+	}
+	return nil
 }

--- a/pkg/server/helpers.go
+++ b/pkg/server/helpers.go
@@ -85,6 +85,8 @@ const (
 	utsNSFormat = "/proc/%v/ns/uts"
 	// pidNSFormat is the format of pid namespace of a process.
 	pidNSFormat = "/proc/%v/ns/pid"
+	// etcHosts is the default path of /etc/hosts file.
+	etcHosts = "/etc/hosts"
 )
 
 // generateID generates a random unique id.
@@ -133,12 +135,18 @@ func getContainerRootDir(rootDir, id string) string {
 	return filepath.Join(rootDir, containersDir, id)
 }
 
-// getStreamingPipes returns the stdin/stdout/stderr pipes path in the root.
+// getStreamingPipes returns the stdin/stdout/stderr pipes path in the
+// container/sandbox root.
 func getStreamingPipes(rootDir string) (string, string, string) {
 	stdin := filepath.Join(rootDir, stdinNamedPipe)
 	stdout := filepath.Join(rootDir, stdoutNamedPipe)
 	stderr := filepath.Join(rootDir, stderrNamedPipe)
 	return stdin, stdout, stderr
+}
+
+// getSandboxHosts returns the hosts file path inside the sandbox root directory.
+func getSandboxHosts(sandboxRootDir string) string {
+	return filepath.Join(sandboxRootDir, "hosts")
 }
 
 // prepareStreamingPipes prepares stream named pipe for container. returns nil

--- a/pkg/server/sandbox_run_test.go
+++ b/pkg/server/sandbox_run_test.go
@@ -157,6 +157,21 @@ func TestGenerateSandboxContainerSpec(t *testing.T) {
 	}
 }
 
+func TestSetupSandboxFiles(t *testing.T) {
+	testRootDir := "test-sandbox-root"
+	expectedCopys := [][]interface{}{
+		{"/etc/hosts", testRootDir + "/hosts", os.FileMode(0666)},
+	}
+	c := newTestCRIContainerdService()
+	var copys [][]interface{}
+	c.os.(*ostesting.FakeOS).CopyFileFn = func(src string, dest string, perm os.FileMode) error {
+		copys = append(copys, []interface{}{src, dest, perm})
+		return nil
+	}
+	c.setupSandboxFiles(testRootDir, nil)
+	assert.Equal(t, expectedCopys, copys, "should copy /etc/hosts for sandbox")
+}
+
 func TestRunPodSandbox(t *testing.T) {
 	config, imageConfig, specCheck := getRunPodSandboxTestData()
 	c := newTestCRIContainerdService()


### PR DESCRIPTION
Add sandbox `/etc/hosts` and mount it inside each container of the sandbox.

Currently, in Kubelet,
* For `/etc/hosts`, we mount it when the sandbox is not using host network, and rely on the runtime to maintain it if the sandbox is using host network.
* For `/etc/resolv.conf`, we rely on the runtime to maintain it (dockershim overwrites it after creates sandbox container).

From the perspective of a runtime, it's weird that we only maintain the file in some cases, and not in other cases.

So in this PR, I'll let `cri-containerd` always maintain `/etc/hosts` no matter the sandbox is using host network or not.

In the future, we should make it consistent:
1) Either let kubelet manage all those files;
2) Let runtime manage all those files.

/cc @yujuhong 

