### PR TITLE
adds support for v prefix in release tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,9 @@ BUILD_DIR ?= _output
 # VERSION is derived from the current tag for HEAD plus amends. Version is used
 # to set/overide the criContainerdVersion variable in the verison package for
 # cri-containerd.
-VERSION:=$(shell git describe --tags --dirty)
+VERSION := $(shell git describe --tags --dirty)
+# strip the first char of the tag if it's a `v`
+VERSION := $(VERSION:v%=%)
 BUILD_TAGS:= -ldflags '-X $(PROJECT)/pkg/version.criContainerdVersion=$(VERSION)'
 
 all: binaries


### PR DESCRIPTION
Fixes the issue where we could not use the `v` prefix for release tags.  semver 2.0 removed support for the v prefix.  Still the v prefix is commonly used and expected on release tags in git repos. 

The solution here is to allow for the v prefix on the release tag, but to remove the prefix before setting the version variable in the version package. This way the reported version is sans the v.. but the displayed version includes the v in git hub. 

Signed-off-by: Mike Brown <brownwm@us.ibm.com>