### PR TITLE
Use containerd version returned by version service.

### DIFF
--- a/pkg/server/version.go
+++ b/pkg/server/version.go
@@ -28,23 +28,20 @@ import (
 const (
 	containerName        = "containerd"
 	containerdAPIVersion = "0.0.0"
-	containerdVersion    = "0.0.0"
 	// kubeAPIVersion is the api version of kubernetes.
 	kubeAPIVersion = "0.1.0"
 )
 
 // Version returns the runtime name, runtime version and runtime API version.
 func (c *criContainerdService) Version(ctx context.Context, r *runtime.VersionRequest) (*runtime.VersionResponse, error) {
-	_, err := c.versionService.Version(ctx, &empty.Empty{})
+	resp, err := c.versionService.Version(ctx, &empty.Empty{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get containerd version: %v", err)
 	}
 	return &runtime.VersionResponse{
-		Version:     kubeAPIVersion,
-		RuntimeName: containerName,
-		// Containerd doesn't return semver because of a bug.
-		// TODO(random-liu): Replace this with version from containerd.
-		RuntimeVersion: containerdVersion,
+		Version:        kubeAPIVersion,
+		RuntimeName:    containerName,
+		RuntimeVersion: resp.Version,
 		// Containerd doesn't have an api version now.
 		RuntimeApiVersion: containerdAPIVersion,
 	}, nil

--- a/pkg/server/version_test.go
+++ b/pkg/server/version_test.go
@@ -35,9 +35,10 @@ func TestVersion(t *testing.T) {
 	defer ctrl.Finish()
 	// TODO(random-liu): Check containerd version after containerd fixes its version.
 	for desc, test := range map[string]struct {
-		versionRes *versionapi.VersionResponse
-		versionErr error
-		expectErr  bool
+		versionRes      *versionapi.VersionResponse
+		versionErr      error
+		expectErr       bool
+		expectedVersion string
 	}{
 		"should return error if containerd version returns error": {
 			versionErr: errors.New("random error"),
@@ -55,7 +56,11 @@ func TestVersion(t *testing.T) {
 		mock.EXPECT().Version(ctx, &empty.Empty{}).Return(test.versionRes, test.versionErr)
 
 		c.versionService = mock
-		_, err := c.Version(ctx, &runtime.VersionRequest{})
-		assert.Equal(t, test.expectErr, err != nil)
+		v, err := c.Version(ctx, &runtime.VersionRequest{})
+		if test.expectErr {
+			assert.Equal(t, test.expectErr, err != nil)
+		} else {
+			assert.Equal(t, test.versionRes.Version, v.RuntimeVersion)
+		}
 	}
 }


### PR DESCRIPTION
A small PR to use containerd version returned by version service.

As is mentioned in https://github.com/kubernetes-incubator/cri-containerd/issues/62#issuecomment-306638697, containerd will return proper version after a tag with description is created.

Now version service returns commit number. It's fine for now, only problem is that runtime version will be shown as `Unknown` by kubernetes, because it's not a semver.

Signed-off-by: Lantao Liu <lantaol@google.com>