### PR TITLE
Fix capabilities support.

### DIFF
--- a/pkg/server/container_start.go
+++ b/pkg/server/container_start.go
@@ -467,14 +467,15 @@ func setOCICapabilities(g *generate.Generator, capabilities *runtime.Capability,
 		return nil
 	}
 
+	// Capabilities in CRI doesn't have `CAP_` prefix, so add it.
 	for _, c := range capabilities.GetAddCapabilities() {
-		if err := g.AddProcessCapability(c); err != nil {
+		if err := g.AddProcessCapability("CAP_" + c); err != nil {
 			return err
 		}
 	}
 
 	for _, c := range capabilities.GetDropCapabilities() {
-		if err := g.DropProcessCapability(c); err != nil {
+		if err := g.DropProcessCapability("CAP_" + c); err != nil {
 			return err
 		}
 	}

--- a/pkg/server/container_start_test.go
+++ b/pkg/server/container_start_test.go
@@ -77,8 +77,8 @@ func getStartContainerTestData() (*runtime.ContainerConfig, *runtime.PodSandboxC
 			},
 			SecurityContext: &runtime.LinuxContainerSecurityContext{
 				Capabilities: &runtime.Capability{
-					AddCapabilities:  []string{"CAP_SYS_ADMIN"},
-					DropCapabilities: []string{"CAP_CHOWN"},
+					AddCapabilities:  []string{"SYS_ADMIN"},
+					DropCapabilities: []string{"CHOWN"},
 				},
 				SupplementalGroups: []int64{1111, 2222},
 			},


### PR DESCRIPTION
The capabilities in CRI and docker doesn't have the `CAP_` prefix. However, we need to add it when generating the runtime spec.

With another `ExecSync` PR I'll send out soon, we can pass the capabilities cri validation test now:
```
# critest --runtime-endpoint=/var/run/cri-containerd.sock --focus=Capabili validation
Running Suite: E2ECRI Suite
===========================
Random Seed: 1497147284 - Will randomize all specs
Will run 1 of 36 specs

SSSSSSSSSSSSSSSSS
------------------------------
[k8s.io] Security Context runtime should support container with security context 
  runtime should support setting Capability
  /home/lantaol/workspace/src/github.com/kubernetes-incubator/cri-tools/pkg/validate/security_context.go:369
[BeforeEach] [k8s.io] Security Context
  /home/lantaol/workspace/src/github.com/kubernetes-incubator/cri-tools/pkg/framework/framework.go:50
[BeforeEach] [k8s.io] Security Context
  /home/lantaol/workspace/src/github.com/kubernetes-incubator/cri-tools/pkg/validate/security_context.go:49
[It] runtime should support setting Capability
  /home/lantaol/workspace/src/github.com/kubernetes-incubator/cri-tools/pkg/validate/security_context.go:369
STEP: create pod
STEP: create container with security context Capability and test
STEP: create Capability container
STEP: Get image status for image: busybox:1.26
STEP: Pull image : busybox:1.26
STEP: Create container.
Jun 11 02:14:47.629: INFO: Created container "0f7d2fc7b86e3816c237819af959492b25f2ab39f81c222533e586b2ebfddd47"

STEP: Start container for containerID: 0f7d2fc7b86e3816c237819af959492b25f2ab39f81c222533e586b2ebfddd47
Jun 11 02:14:47.754: INFO: Started container "0f7d2fc7b86e3816c237819af959492b25f2ab39f81c222533e586b2ebfddd47"

STEP: Get container status for containerID: 0f7d2fc7b86e3816c237819af959492b25f2ab39f81c222533e586b2ebfddd47
STEP: create container without security context Capability and test
STEP: Get image status for image: busybox:1.26
STEP: Create container.
Jun 11 02:14:47.813: INFO: Created container "20abe0a3e304364ef0aeeb65cb617f1fda3dc82d4f322d0a592801ab415aeb52"

STEP: Start container for containerID: 20abe0a3e304364ef0aeeb65cb617f1fda3dc82d4f322d0a592801ab415aeb52
Jun 11 02:14:47.928: INFO: Started container "20abe0a3e304364ef0aeeb65cb617f1fda3dc82d4f322d0a592801ab415aeb52"

STEP: Get container status for containerID: 20abe0a3e304364ef0aeeb65cb617f1fda3dc82d4f322d0a592801ab415aeb52
[AfterEach] runtime should support container with security context
  /home/lantaol/workspace/src/github.com/kubernetes-incubator/cri-tools/pkg/validate/security_context.go:235
STEP: stop PodSandbox
STEP: delete PodSandbox
[AfterEach] [k8s.io] Security Context
  /home/lantaol/workspace/src/github.com/kubernetes-incubator/cri-tools/pkg/framework/framework.go:51
•SSSSSSSSSSSSSSSSSS
Ran 1 of 36 Specs in 3.215 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 35 Skipped PASS

Ginkgo ran 1 suite in 3.284995122s
Test Suite Passed
```
/cc @heartlock 
Signed-off-by: Lantao Liu <lantaol@google.com>