### PR TITLE
Fix Delete race.

### DIFF
--- a/pkg/server/helpers.go
+++ b/pkg/server/helpers.go
@@ -226,6 +226,13 @@ func isContainerdContainerNotExistError(grpcError error) bool {
 	return grpc.ErrorDesc(grpcError) == containerd.ErrContainerNotExist.Error()
 }
 
+// isRuncProcessAlreadyFinishedError checks whether a grpc error is a process already
+// finished error.
+// TODO(random-liu): Containerd should expose this error in api. (containerd#999)
+func isRuncProcessAlreadyFinishedError(grpcError error) bool {
+	return strings.Contains(grpc.ErrorDesc(grpcError), "os: process already finished")
+}
+
 // getSandbox gets the sandbox metadata from the sandbox store. It returns nil without
 // error if the sandbox metadata is not found. It also tries to get full sandbox id and
 // retry if the sandbox metadata is not found with the initial id.

--- a/pkg/server/testing/fake_execution_client.go
+++ b/pkg/server/testing/fake_execution_client.go
@@ -31,7 +31,8 @@ import (
 	"google.golang.org/grpc/codes"
 )
 
-var containerNotExistError = grpc.Errorf(codes.Unknown, containerd.ErrContainerNotExist.Error())
+// ContainerNotExistError is the fake error returned when container does not exist.
+var ContainerNotExistError = grpc.Errorf(codes.Unknown, containerd.ErrContainerNotExist.Error())
 
 // CalledDetail is the struct contains called function name and arguments.
 type CalledDetail struct {
@@ -229,7 +230,7 @@ func (f *FakeExecutionClient) Start(ctx context.Context, startOpts *execution.St
 	}
 	c, ok := f.ContainerList[startOpts.ID]
 	if !ok {
-		return nil, containerNotExistError
+		return nil, ContainerNotExistError
 	}
 	f.sendEvent(&container.Event{
 		ID:   c.ID,
@@ -260,7 +261,7 @@ func (f *FakeExecutionClient) Delete(ctx context.Context, deleteOpts *execution.
 	}
 	c, ok := f.ContainerList[deleteOpts.ID]
 	if !ok {
-		return nil, containerNotExistError
+		return nil, ContainerNotExistError
 	}
 	delete(f.ContainerList, deleteOpts.ID)
 	f.sendEvent(&container.Event{
@@ -281,7 +282,7 @@ func (f *FakeExecutionClient) Info(ctx context.Context, infoOpts *execution.Info
 	}
 	c, ok := f.ContainerList[infoOpts.ID]
 	if !ok {
-		return nil, containerNotExistError
+		return nil, ContainerNotExistError
 	}
 	return &c, nil
 }
@@ -315,7 +316,7 @@ func (f *FakeExecutionClient) Kill(ctx context.Context, killOpts *execution.Kill
 	}
 	c, ok := f.ContainerList[killOpts.ID]
 	if !ok {
-		return nil, containerNotExistError
+		return nil, ContainerNotExistError
 	}
 	c.Status = container.Status_STOPPED
 	f.ContainerList[killOpts.ID] = c


### PR DESCRIPTION
1. Fix a `Delete` race between `container_stop.go` and `event.go`.

Initially, I thought `Delete` is thread safe. However, I found that if there are 2 on-going `Delete`s, one may stop the shim already, but the other one may have get the container index from containerd and try to access shim and get a `"transport is closing"` error. This seems to be expected behavior. /cc @crosbymichael

Actually I think we should not let `container_stop.go` `Delete` the container before event handler properly handles the exit event, so we should use `Kill` in `container_stop.go`.

2. Ignore `Kill` errors.
Another change made by this PR is to ignore `Kill` error, because when process is already stopped, `Kill` will return an `os: process already finished` error, [which is expected](https://github.com/opencontainers/runtime-spec/blob/master/runtime.md#kill).

So in this PR, we only log an error for `Kill` error, and rely on the following `WaitStop` to figure out whether the container is successfully stopped or not. Which is also similar with [what docker is doing today](https://github.com/moby/moby/blob/master/daemon/stop.go#L85).

This PR also shortens the kill container timeout so that if containerd is down or `Kill` returns error, we could get an error sooner.

Signed-off-by: Lantao Liu <lantaol@google.com>