### PR TITLE
Add the missing loop in event handler.

### DIFF
--- a/pkg/server/events.go
+++ b/pkg/server/events.go
@@ -58,10 +58,11 @@ func (c *criContainerdService) startEventMonitor() {
 			b.Reset()
 			// TODO(random-liu): Relist to recover state, should prevent other operations
 			// until state is fully recovered.
-			if err := c.handleEventStream(events); err != nil {
-				glog.Errorf("Failed to handle event stream: %v", err)
-				time.Sleep(b.Duration())
-				continue
+			for {
+				if err := c.handleEventStream(events); err != nil {
+					glog.Errorf("Failed to handle event stream: %v", err)
+					break
+				}
 			}
 		}
 	}()


### PR DESCRIPTION
I missed the event loop in https://github.com/kubernetes-incubator/cri-containerd/pull/59. Added it back.

Signed-off-by: Lantao Liu <lantaol@google.com>