### PR TITLE
Fix a race that fake execution client sends event to closed channel.

### DIFF
--- a/pkg/server/testing/fake_execution_client.go
+++ b/pkg/server/testing/fake_execution_client.go
@@ -89,6 +89,7 @@ func (f *FakeExecutionClient) Stop() {
 	for _, client := range f.eventClients {
 		close(client.Events)
 	}
+	f.eventClients = nil
 }
 
 // WithEvents setup events publisher for FakeExecutionClient


### PR DESCRIPTION
We should clear the client list after close all event client channels. Or else [this line](https://github.com/Random-Liu/cri-containerd/blob/2ae22b33b7de6d327369aa35da66f6d4acd9c194/pkg/server/testing/fake_execution_client.go#L102) may send event to the closed channel which causes a panic.

Signed-off-by: Lantao Liu <lantaol@google.com>