### PR TITLE
Register all possible repo tags and repo digests.

### DIFF
--- a/pkg/server/helpers.go
+++ b/pkg/server/helpers.go
@@ -330,12 +330,17 @@ func (c *criContainerdService) getImageInfo(ctx context.Context, ref string) (
 }
 
 // getRepoDigestAngTag returns image repoDigest and repoTag of the named image reference.
-func getRepoDigestAndTag(namedRef reference.Named, digest imagedigest.Digest) (string, string) {
-	var repoTag string
+func getRepoDigestAndTag(namedRef reference.Named, digest imagedigest.Digest, schema1 bool) (string, string) {
+	var repoTag, repoDigest string
 	if _, ok := namedRef.(reference.NamedTagged); ok {
 		repoTag = namedRef.String()
 	}
-	repoDigest := namedRef.Name() + "@" + digest.String()
+	if _, ok := namedRef.(reference.Canonical); ok {
+		repoDigest = namedRef.String()
+	} else if !schema1 {
+		// digest is not actual repo digest for schema1 image.
+		repoDigest = namedRef.Name() + "@" + digest.String()
+	}
 	return repoDigest, repoTag
 }
 

--- a/pkg/server/helpers_test.go
+++ b/pkg/server/helpers_test.go
@@ -265,6 +265,7 @@ func TestGetRepoDigestAndTag(t *testing.T) {
 	digest := imagedigest.Digest("sha256:e6693c20186f837fc393390135d8a598a96a833917917789d63766cab6c59582")
 	for desc, test := range map[string]struct {
 		ref                string
+		schema1            bool
 		expectedRepoDigest string
 		expectedRepoTag    string
 	}{
@@ -277,11 +278,23 @@ func TestGetRepoDigestAndTag(t *testing.T) {
 			expectedRepoDigest: "gcr.io/library/busybox@" + digest.String(),
 			expectedRepoTag:    "gcr.io/library/busybox:latest",
 		},
+		"repo digest should be empty if original ref is schema1 and has no digest": {
+			ref:                "gcr.io/library/busybox:latest",
+			schema1:            true,
+			expectedRepoDigest: "",
+			expectedRepoTag:    "gcr.io/library/busybox:latest",
+		},
+		"repo digest should not be empty if orignal ref is schema1 but has digest": {
+			ref:                "gcr.io/library/busybox@sha256:e6693c20186f837fc393390135d8a598a96a833917917789d63766cab6c59594",
+			schema1:            true,
+			expectedRepoDigest: "gcr.io/library/busybox@sha256:e6693c20186f837fc393390135d8a598a96a833917917789d63766cab6c59594",
+			expectedRepoTag:    "",
+		},
 	} {
 		t.Logf("TestCase %q", desc)
 		named, err := normalizeImageRef(test.ref)
 		assert.NoError(t, err)
-		repoDigest, repoTag := getRepoDigestAndTag(named, digest)
+		repoDigest, repoTag := getRepoDigestAndTag(named, digest, test.schema1)
 		assert.Equal(t, test.expectedRepoDigest, repoDigest)
 		assert.Equal(t, test.expectedRepoTag, repoTag)
 	}


### PR DESCRIPTION
Register both repo tag and repo digest when pulling image.

Currently, Kubelet assumes that once image is pulled with repo tag, the repo digest also needs to be stored as existing reference.

Signed-off-by: Lantao Liu <lantaol@google.com>