### PR TITLE
Add pull image authentication.

### DIFF
--- a/pkg/server/image_pull_test.go
+++ b/pkg/server/image_pull_test.go
@@ -17,11 +17,13 @@ limitations under the License.
 package server
 
 import (
+	"encoding/base64"
 	"fmt"
 	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
 
 	"github.com/kubernetes-incubator/cri-containerd/pkg/metadata"
 )
@@ -91,5 +93,54 @@ func TestResources(t *testing.T) {
 	for i := 0; i < threads; i++ {
 		_, ok := refs[fmt.Sprintf("sha256:%d", i)]
 		assert.True(t, ok)
+	}
+}
+
+func TestParseAuth(t *testing.T) {
+	testUser := "username"
+	testPasswd := "password"
+	testAuthLen := base64.StdEncoding.EncodedLen(len(testUser + ":" + testPasswd))
+	testAuth := make([]byte, testAuthLen)
+	base64.StdEncoding.Encode(testAuth, []byte(testUser+":"+testPasswd))
+	invalidAuth := make([]byte, testAuthLen)
+	base64.StdEncoding.Encode(invalidAuth, []byte(testUser+"@"+testPasswd))
+	for desc, test := range map[string]struct {
+		auth           *runtime.AuthConfig
+		expectedUser   string
+		expectedSecret string
+		expectErr      bool
+	}{
+		"should not return error if auth config is nil": {},
+		"should return error if no supported auth is provided": {
+			auth:      &runtime.AuthConfig{},
+			expectErr: true,
+		},
+		"should support identity token": {
+			auth:           &runtime.AuthConfig{IdentityToken: "abcd"},
+			expectedSecret: "abcd",
+		},
+		"should support username and password": {
+			auth: &runtime.AuthConfig{
+				Username: testUser,
+				Password: testPasswd,
+			},
+			expectedUser:   testUser,
+			expectedSecret: testPasswd,
+		},
+		"should support auth": {
+			auth:           &runtime.AuthConfig{Auth: string(testAuth)},
+			expectedUser:   testUser,
+			expectedSecret: testPasswd,
+		},
+		"should return error for invalid auth": {
+			auth:      &runtime.AuthConfig{Auth: string(invalidAuth)},
+			expectErr: true,
+		},
+	} {
+		t.Logf("TestCase %q", desc)
+		u, s, err := ParseAuth(test.auth)
+		assert.Equal(t, test.expectErr, err != nil)
+		assert.Equal(t, test.expectedUser, u)
+		assert.Equal(t, test.expectedSecret, s)
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/kubernetes-incubator/cri-containerd/issues/58.

I've tried this PR with a private image `taotaotheripper/node-problem-detector:v0.2`, it works.

However, [the node e2e test](https://github.com/kubernetes/kubernetes/blob/master/test/e2e_node/runtime_conformance_test.go#L296) is still failing because of https://github.com/containerd/containerd/issues/1064, which should possibly be fixed in containerd.

Signed-off-by: Lantao Liu <lantaol@google.com>