### PR TITLE
Set sandbox container resource limit.

### DIFF
--- a/pkg/server/helpers.go
+++ b/pkg/server/helpers.go
@@ -57,6 +57,10 @@ const (
 const (
 	// defaultSandboxImage is the image used by sandbox container.
 	defaultSandboxImage = "gcr.io/google_containers/pause:3.0"
+	// defaultSandboxOOMAdj is default omm adj for sandbox container. (kubernetes#47938).
+	defaultSandboxOOMAdj = -998
+	// defaultSandboxCPUshares is default cpu shares for sandbox container.
+	defaultSandboxCPUshares = 2
 	// defaultShmSize is the default size of the sandbox shm.
 	defaultShmSize = int64(1024 * 1024 * 64)
 	// relativeRootfsPath is the rootfs path relative to bundle path.

--- a/pkg/server/sandbox_run.go
+++ b/pkg/server/sandbox_run.go
@@ -326,7 +326,8 @@ func (c *criContainerdService) generateSandboxContainerSpec(id string, config *r
 
 	// TODO(random-liu): [P2] Set apparmor and seccomp from annotations.
 
-	// TODO(random-liu): [P1] Set default sandbox container resource limit.
+	g.SetLinuxResourcesCPUShares(uint64(defaultSandboxCPUshares))
+	g.SetLinuxResourcesOOMScoreAdj(int(defaultSandboxOOMAdj))
 
 	return g.Spec(), nil
 }

--- a/pkg/server/sandbox_run_test.go
+++ b/pkg/server/sandbox_run_test.go
@@ -68,6 +68,8 @@ func getRunPodSandboxTestData() (*runtime.PodSandboxConfig, *imagespec.ImageConf
 		assert.Contains(t, spec.Process.Env, "a=b", "c=d")
 		assert.Equal(t, []string{"/pause", "forever"}, spec.Process.Args)
 		assert.Equal(t, "/workspace", spec.Process.Cwd)
+		assert.EqualValues(t, *spec.Linux.Resources.CPU.Shares, defaultSandboxCPUshares)
+		assert.EqualValues(t, *spec.Linux.Resources.OOMScoreAdj, defaultSandboxOOMAdj)
 	}
 	return config, imageConfig, specCheck
 }


### PR DESCRIPTION
Set default resource limit for sandbox container.

The default value comes from:
* [PodInfraOOMAdj](https://github.com/kubernetes/kubernetes/blob/886e04f1fffbb04faf8a9f9ee141143b2684ae68/pkg/kubelet/qos/policy.go#L29)
* [defaultSandboxCPUshares](https://github.com/kubernetes/kubernetes/blob/7560142e27ba9c0c535695356a14ac169acd7476/pkg/kubelet/dockershim/docker_sandbox.go#L42)

Signed-off-by: Lantao Liu <lantaol@google.com>