### PR TITLE
Do not teardown network namespace when using host network.

### DIFF
--- a/pkg/server/sandbox_stop.go
+++ b/pkg/server/sandbox_stop.go
@@ -68,9 +68,11 @@ func (c *criContainerdService) StopPodSandbox(ctx context.Context, r *runtime.St
 	// Teardown network for sandbox.
 	_, err = c.os.Stat(sandbox.NetNS)
 	if err == nil {
-		if teardownErr := c.netPlugin.TearDownPod(sandbox.NetNS, sandbox.Config.GetMetadata().GetNamespace(),
-			sandbox.Config.GetMetadata().GetName(), id); teardownErr != nil {
-			return nil, fmt.Errorf("failed to destroy network for sandbox %q: %v", id, teardownErr)
+		if !sandbox.Config.GetLinux().GetSecurityContext().GetNamespaceOptions().GetHostNetwork() {
+			if teardownErr := c.netPlugin.TearDownPod(sandbox.NetNS, sandbox.Config.GetMetadata().GetNamespace(),
+				sandbox.Config.GetMetadata().GetName(), id); teardownErr != nil {
+				return nil, fmt.Errorf("failed to destroy network for sandbox %q: %v", id, teardownErr)
+			}
 		}
 	} else if !os.IsNotExist(err) { // It's ok for sandbox.NetNS to *not* exist
 		return nil, fmt.Errorf("failed to stat netns path for sandbox %q before tearing down the network: %v", id, err)


### PR DESCRIPTION
We should not teardown pod network when sandbox is using host network.

@xlgao-zju Could you help me review this?

Signed-off-by: Lantao Liu <lantaol@google.com>