### PR TITLE
Change containerd log level to debug for cri validation test.

### DIFF
--- a/hack/test-cri.sh
+++ b/hack/test-cri.sh
@@ -60,7 +60,7 @@ if [ ! -x "$(command -v containerd)" ]; then
   exit 1
 fi
 sudo pkill containerd
-sudo containerd &> ${REPORT_DIR}/containerd.log &
+sudo containerd -l debug &> ${REPORT_DIR}/containerd.log &
 
 # Start cri-containerd
 cd ${ROOT}


### PR DESCRIPTION
CHange containerd log level to debug for better debugging.

Signed-off-by: Lantao Liu <lantaol@google.com>