### PR TITLE
Add script to rewrite `Sirupsen` to `sirupsen` in vendor.

### DIFF
--- a/hack/update-vendor.sh
+++ b/hack/update-vendor.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# This is a temporary hack, rewrite all `github.com/Sirupsen/logrus` to
+# lower case.
+# TODO(random-liu): Remove this after #106 is resolved.
+ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"/..
+cd ${ROOT}
+find vendor/ -name *.go | xargs sed -i 's/"github.com\/Sirupsen\/logrus"/"github.com\/sirupsen\/logrus"/g'
+echo "Please commit the change made by this file..."

--- a/vendor/github.com/docker/docker/pkg/signal/trap.go
+++ b/vendor/github.com/docker/docker/pkg/signal/trap.go
@@ -11,7 +11,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/pkg/errors"
 )
 

--- a/vendor/github.com/kubernetes-incubator/cri-o/pkg/ocicni/ocicni.go
+++ b/vendor/github.com/kubernetes-incubator/cri-o/pkg/ocicni/ocicni.go
@@ -7,7 +7,7 @@ import (
 	"sort"
 	"sync"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/containernetworking/cni/libcni"
 	cnitypes "github.com/containernetworking/cni/pkg/types"
 	"github.com/fsnotify/fsnotify"


### PR DESCRIPTION
`sirupsen` was changed to upper case in https://github.com/kubernetes-incubator/cri-containerd/pull/110, which causes problem.

Travis could still build, because there is `Sirupsen` cached in `$GOPATH`, and upper case `Sirupsen` in `$GOPATH` still works but doesn't work in `vendor`, which seems to be a golang problem.

Anyway, we need to rewrite until https://github.com/kubernetes-incubator/cri-containerd/issues/106 is fixed.

Signed-off-by: Lantao Liu <lantaol@google.com>