### PR TITLE
Handle device symlink.

### DIFF
--- a/pkg/server/helpers.go
+++ b/pkg/server/helpers.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -401,4 +402,17 @@ func (c *criContainerdService) ensureImageExists(ctx context.Context, ref string
 		return nil, fmt.Errorf("failed to get image %q metadata after pulling: %v", imageID, err)
 	}
 	return &newImage, nil
+}
+
+// resolveSymbolicLink resolves a possbile symlink path. If the path is a symlink, returns resolved
+// path; if not, returns the original path.
+func resolveSymbolicLink(path string) (string, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return "", err
+	}
+	if info.Mode()&os.ModeSymlink != os.ModeSymlink {
+		return path, nil
+	}
+	return filepath.EvalSymlinks(path)
 }


### PR DESCRIPTION
I found that cri-containerd prints out a lot of following logs when running privileged container test:
```
WARNING: The same type, major and minor should not be used for multiple devices.
```

It turns out that device list returned by `HostDevices` also contains all the device symlinks with 0 major & minor.

This PR:
1) Skip these 0 major minor devices for privileged container;
2) Follow symlink for non-privileged container, which is [the same with docker](https://github.com/moby/moby/blob/7238cca42c3d024adfa030306ad3e3ec4232baed/oci/devices_linux.go#L45).

/cc @kubernetes-incubator/maintainers-cri-containerd 
Signed-off-by: Lantao Liu <lantaol@google.com>