### PR TITLE
Replace the original default spec with containerd default spec

### DIFF
--- a/pkg/server/container_create.go
+++ b/pkg/server/container_create.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/containers"
 	prototypes "github.com/gogo/protobuf/types"
 	"github.com/golang/glog"
@@ -181,7 +182,11 @@ func (c *criContainerdService) CreateContainer(ctx context.Context, r *runtime.C
 func (c *criContainerdService) generateContainerSpec(id string, sandboxPid uint32, config *runtime.ContainerConfig,
 	sandboxConfig *runtime.PodSandboxConfig, imageConfig *imagespec.ImageConfig, extraMounts []*runtime.Mount) (*runtimespec.Spec, error) {
 	// Creates a spec Generator with the default spec.
-	g := generate.New()
+	spec, err := containerd.GenerateSpec()
+	if err != nil {
+		return nil, err
+	}
+	g := generate.NewFromSpec(spec)
 
 	// Set the relative path to the rootfs of the container from containerd's
 	// pre-defined directory.

--- a/pkg/server/sandbox_run.go
+++ b/pkg/server/sandbox_run.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/api/services/tasks/v1"
 	"github.com/containerd/containerd/api/types"
 	"github.com/containerd/containerd/containers"
@@ -241,7 +242,11 @@ func (c *criContainerdService) generateSandboxContainerSpec(id string, config *r
 	imageConfig *imagespec.ImageConfig) (*runtimespec.Spec, error) {
 	// Creates a spec Generator with the default spec.
 	// TODO(random-liu): [P1] Compare the default settings with docker and containerd default.
-	g := generate.New()
+	spec, err := containerd.GenerateSpec()
+	if err != nil {
+		return nil, err
+	}
+	g := generate.NewFromSpec(spec)
 
 	// Apply default config from image config.
 	if err := addImageEnvs(&g, imageConfig.Env); err != nil {


### PR DESCRIPTION
The original default spec contain `seccomp` configuration, but some OS do not support this feature, such as ubuntu14.04, and `make test-cri` always fail. The containerd default spec dosen't contain `seccomp`, so I think we could replace the default spec with containerd default spec.

The difference between original default spec and containerd default spec:

| original default spec | containerd default spec |
|---------------------------|-------------------------------|
| - | mounts: /run |
| seccomp | - |
| process.capabilities.ambient | - |
| env: TERM=xterm | - |


Signed-off-by: Yanqiang Miao <miao.yanqiang@zte.com.cn>