### PR TITLE
Use containerd spec generator to set tty.

### DIFF
--- a/pkg/server/container_create.go
+++ b/pkg/server/container_create.go
@@ -202,6 +202,11 @@ func (c *criContainerdService) generateContainerSpec(id string, sandboxPid uint3
 		g.SetProcessCwd(imageConfig.WorkingDir)
 	}
 
+	g.SetProcessTerminal(config.GetTty())
+	if config.GetTty() {
+		g.AddProcessEnv("TERM", "xterm")
+	}
+
 	// Apply envs from image config first, so that envs from container config
 	// can override them.
 	if err := addImageEnvs(&g, imageConfig.Env); err != nil {
@@ -229,8 +234,6 @@ func (c *criContainerdService) generateContainerSpec(id string, sandboxPid uint3
 		cgroupsPath := getCgroupsPath(sandboxConfig.GetLinux().GetCgroupParent(), id)
 		g.SetLinuxCgroupsPath(cgroupsPath)
 	}
-
-	g.SetProcessTerminal(config.GetTty())
 
 	if err := setOCICapabilities(&g, securityContext.GetCapabilities(), securityContext.GetPrivileged()); err != nil {
 		return nil, fmt.Errorf("failed to set capabilities %+v: %v",

--- a/pkg/server/container_create_test.go
+++ b/pkg/server/container_create_test.go
@@ -191,6 +191,11 @@ func TestContainerSpecTty(t *testing.T) {
 		assert.NoError(t, err)
 		specCheck(t, testID, testPid, spec)
 		assert.Equal(t, tty, spec.Process.Terminal)
+		if tty {
+			assert.Contains(t, spec.Process.Env, "TERM=xterm")
+		} else {
+			assert.NotContains(t, spec.Process.Env, "TERM=xterm")
+		}
 	}
 }
 


### PR DESCRIPTION
In https://github.com/kubernetes-incubator/cri-containerd/pull/126, we changed to use containerd default spec.

However, because containerd doesn't add `TERM=xterm` by default, it needs to be added separately when tty is enabled.

This is not done in runtime-tools, but is handled in containerd `WithTTY`, so we'll use containerd spec generator to set TTY.

Signed-off-by: Lantao Liu <lantaol@google.com>

/cc @miaoyq 