### PR TITLE
Add instrumented service.

### DIFF
--- a/pkg/server/container_create.go
+++ b/pkg/server/container_create.go
@@ -34,15 +34,7 @@ import (
 )
 
 // CreateContainer creates a new container in the given PodSandbox.
-func (c *criContainerdService) CreateContainer(ctx context.Context, r *runtime.CreateContainerRequest) (retRes *runtime.CreateContainerResponse, retErr error) {
-	glog.V(2).Infof("CreateContainer within sandbox %q with container config %+v and sandbox config %+v",
-		r.GetPodSandboxId(), r.GetConfig(), r.GetSandboxConfig())
-	defer func() {
-		if retErr == nil {
-			glog.V(2).Infof("CreateContainer returns container id %q", retRes.GetContainerId())
-		}
-	}()
-
+func (c *criContainerdService) CreateContainer(ctx context.Context, r *runtime.CreateContainerRequest) (_ *runtime.CreateContainerResponse, retErr error) {
 	config := r.GetConfig()
 	sandboxConfig := r.GetSandboxConfig()
 	sandbox, err := c.sandboxStore.Get(r.GetPodSandboxId())

--- a/pkg/server/container_exec.go
+++ b/pkg/server/container_exec.go
@@ -19,21 +19,12 @@ package server
 import (
 	"fmt"
 
-	"github.com/golang/glog"
 	"golang.org/x/net/context"
 	"k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
 )
 
 // Exec prepares a streaming endpoint to execute a command in the container, and returns the address.
-func (c *criContainerdService) Exec(ctx context.Context, r *runtime.ExecRequest) (retRes *runtime.ExecResponse, retErr error) {
-	glog.V(2).Infof("Exec for %q with command %+v, tty %v and stdin %v",
-		r.GetContainerId(), r.GetCmd(), r.GetTty(), r.GetStdin())
-	defer func() {
-		if retErr == nil {
-			glog.V(2).Infof("Exec for %q returns URL %q", r.GetContainerId(), retRes.GetUrl())
-		}
-	}()
-
+func (c *criContainerdService) Exec(ctx context.Context, r *runtime.ExecRequest) (*runtime.ExecResponse, error) {
 	cntr, err := c.containerStore.Get(r.GetContainerId())
 	if err != nil {
 		return nil, fmt.Errorf("failed to find container in store: %v", err)

--- a/pkg/server/container_execsync.go
+++ b/pkg/server/container_execsync.go
@@ -33,16 +33,7 @@ import (
 
 // ExecSync executes a command in the container, and returns the stdout output.
 // If command exits with a non-zero exit code, an error is returned.
-func (c *criContainerdService) ExecSync(ctx context.Context, r *runtime.ExecSyncRequest) (retRes *runtime.ExecSyncResponse, retErr error) {
-	glog.V(2).Infof("ExecSync for %q with command %+v and timeout %d (s)", r.GetContainerId(), r.GetCmd(), r.GetTimeout())
-	defer func() {
-		if retErr == nil {
-			glog.V(2).Infof("ExecSync for %q returns with exit code %d", r.GetContainerId(), retRes.GetExitCode())
-			glog.V(4).Infof("ExecSync for %q outputs - stdout: %q, stderr: %q", r.GetContainerId(),
-				retRes.GetStdout(), retRes.GetStderr())
-		}
-	}()
-
+func (c *criContainerdService) ExecSync(ctx context.Context, r *runtime.ExecSyncRequest) (*runtime.ExecSyncResponse, error) {
 	var stdout, stderr bytes.Buffer
 	exitCode, err := c.execInContainer(ctx, r.GetContainerId(), execOptions{
 		cmd:     r.GetCmd(),

--- a/pkg/server/container_list.go
+++ b/pkg/server/container_list.go
@@ -17,7 +17,6 @@ limitations under the License.
 package server
 
 import (
-	"github.com/golang/glog"
 	"golang.org/x/net/context"
 
 	"k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
@@ -26,14 +25,7 @@ import (
 )
 
 // ListContainers lists all containers matching the filter.
-func (c *criContainerdService) ListContainers(ctx context.Context, r *runtime.ListContainersRequest) (retRes *runtime.ListContainersResponse, retErr error) {
-	glog.V(5).Infof("ListContainers with filter %+v", r.GetFilter())
-	defer func() {
-		if retErr == nil {
-			glog.V(5).Infof("ListContainers returns containers %+v", retRes.GetContainers())
-		}
-	}()
-
+func (c *criContainerdService) ListContainers(ctx context.Context, r *runtime.ListContainersRequest) (*runtime.ListContainersResponse, error) {
 	// List all containers from store.
 	containersInStore := c.containerStore.List()
 

--- a/pkg/server/container_remove.go
+++ b/pkg/server/container_remove.go
@@ -30,14 +30,7 @@ import (
 )
 
 // RemoveContainer removes the container.
-func (c *criContainerdService) RemoveContainer(ctx context.Context, r *runtime.RemoveContainerRequest) (retRes *runtime.RemoveContainerResponse, retErr error) {
-	glog.V(2).Infof("RemoveContainer for %q", r.GetContainerId())
-	defer func() {
-		if retErr == nil {
-			glog.V(2).Infof("RemoveContainer %q returns successfully", r.GetContainerId())
-		}
-	}()
-
+func (c *criContainerdService) RemoveContainer(ctx context.Context, r *runtime.RemoveContainerRequest) (_ *runtime.RemoveContainerResponse, retErr error) {
 	container, err := c.containerStore.Get(r.GetContainerId())
 	if err != nil {
 		if err != store.ErrNotExist {

--- a/pkg/server/container_start.go
+++ b/pkg/server/container_start.go
@@ -34,13 +34,6 @@ import (
 
 // StartContainer starts the container.
 func (c *criContainerdService) StartContainer(ctx context.Context, r *runtime.StartContainerRequest) (retRes *runtime.StartContainerResponse, retErr error) {
-	glog.V(2).Infof("StartContainer for %q", r.GetContainerId())
-	defer func() {
-		if retErr == nil {
-			glog.V(2).Infof("StartContainer %q returns successfully", r.GetContainerId())
-		}
-	}()
-
 	container, err := c.containerStore.Get(r.GetContainerId())
 	if err != nil {
 		return nil, fmt.Errorf("an error occurred when try to find container %q: %v", r.GetContainerId(), err)

--- a/pkg/server/container_status.go
+++ b/pkg/server/container_status.go
@@ -19,7 +19,6 @@ package server
 import (
 	"fmt"
 
-	"github.com/golang/glog"
 	"golang.org/x/net/context"
 	"k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
 
@@ -27,14 +26,7 @@ import (
 )
 
 // ContainerStatus inspects the container and returns the status.
-func (c *criContainerdService) ContainerStatus(ctx context.Context, r *runtime.ContainerStatusRequest) (retRes *runtime.ContainerStatusResponse, retErr error) {
-	glog.V(5).Infof("ContainerStatus for container %q", r.GetContainerId())
-	defer func() {
-		if retErr == nil {
-			glog.V(5).Infof("ContainerStatus for %q returns status %+v", r.GetContainerId(), retRes.GetStatus())
-		}
-	}()
-
+func (c *criContainerdService) ContainerStatus(ctx context.Context, r *runtime.ContainerStatusRequest) (*runtime.ContainerStatusResponse, error) {
 	container, err := c.containerStore.Get(r.GetContainerId())
 	if err != nil {
 		return nil, fmt.Errorf("an error occurred when try to find container %q: %v", r.GetContainerId(), err)

--- a/pkg/server/container_stop.go
+++ b/pkg/server/container_stop.go
@@ -42,14 +42,7 @@ const (
 )
 
 // StopContainer stops a running container with a grace period (i.e., timeout).
-func (c *criContainerdService) StopContainer(ctx context.Context, r *runtime.StopContainerRequest) (retRes *runtime.StopContainerResponse, retErr error) {
-	glog.V(2).Infof("StopContainer for %q with timeout %d (s)", r.GetContainerId(), r.GetTimeout())
-	defer func() {
-		if retErr == nil {
-			glog.V(2).Infof("StopContainer %q returns successfully", r.GetContainerId())
-		}
-	}()
-
+func (c *criContainerdService) StopContainer(ctx context.Context, r *runtime.StopContainerRequest) (*runtime.StopContainerResponse, error) {
 	// Get container config from container store.
 	container, err := c.containerStore.Get(r.GetContainerId())
 	if err != nil {

--- a/pkg/server/container_update_resources.go
+++ b/pkg/server/container_update_resources.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 
 	"github.com/containerd/containerd"
-	"github.com/golang/glog"
 	"github.com/golang/protobuf/proto"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	"golang.org/x/net/context"
@@ -29,12 +28,6 @@ import (
 
 // UpdateContainerResources updates ContainerConfig of the container.
 func (c *criContainerdService) UpdateContainerResources(ctx context.Context, r *runtime.UpdateContainerResourcesRequest) (retRes *runtime.UpdateContainerResourcesResponse, retErr error) {
-	glog.V(2).Infof("UpdateContainerResources for container %q with %+v", r.GetContainerId(), r.GetLinux())
-	defer func() {
-		if retErr == nil {
-			glog.V(2).Infof("UpdateContainerResources for container %q returns successfully", r.GetContainerId())
-		}
-	}()
 	cntr, err := c.containerStore.Get(r.GetContainerId())
 	if err != nil {
 		return nil, fmt.Errorf("failed to find container: %v", err)

--- a/pkg/server/image_list.go
+++ b/pkg/server/image_list.go
@@ -17,7 +17,6 @@ limitations under the License.
 package server
 
 import (
-	"github.com/golang/glog"
 	"golang.org/x/net/context"
 	"k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
 
@@ -27,14 +26,7 @@ import (
 // ListImages lists existing images.
 // TODO(random-liu): Add image list filters after CRI defines this more clear, and kubelet
 // actually needs it.
-func (c *criContainerdService) ListImages(ctx context.Context, r *runtime.ListImagesRequest) (retRes *runtime.ListImagesResponse, retErr error) {
-	glog.V(5).Infof("ListImages with filter %+v", r.GetFilter())
-	defer func() {
-		if retErr == nil {
-			glog.V(5).Infof("ListImages returns image list %+v", retRes.GetImages())
-		}
-	}()
-
+func (c *criContainerdService) ListImages(ctx context.Context, r *runtime.ListImagesRequest) (*runtime.ListImagesResponse, error) {
 	imagesInStore := c.imageStore.List()
 
 	var images []*runtime.Image

--- a/pkg/server/image_pull.go
+++ b/pkg/server/image_pull.go
@@ -73,15 +73,7 @@ import (
 // contents are missing but snapshots are ready, is the image still "READY"?
 
 // PullImage pulls an image with authentication config.
-func (c *criContainerdService) PullImage(ctx context.Context, r *runtime.PullImageRequest) (retRes *runtime.PullImageResponse, retErr error) {
-	glog.V(2).Infof("PullImage %q with auth config %+v", r.GetImage().GetImage(), r.GetAuth())
-	defer func() {
-		if retErr == nil {
-			glog.V(2).Infof("PullImage %q returns image reference %q",
-				r.GetImage().GetImage(), retRes.GetImageRef())
-		}
-	}()
-
+func (c *criContainerdService) PullImage(ctx context.Context, r *runtime.PullImageRequest) (*runtime.PullImageResponse, error) {
 	imageRef := r.GetImage().GetImage()
 	namedRef, err := normalizeImageRef(imageRef)
 	if err != nil {

--- a/pkg/server/image_remove.go
+++ b/pkg/server/image_remove.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 
 	"github.com/containerd/containerd/errdefs"
-	"github.com/golang/glog"
 	"golang.org/x/net/context"
 	"k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
 )
@@ -31,13 +30,7 @@ import (
 // TODO(random-liu): We should change CRI to distinguish image id and image spec.
 // Remove the whole image no matter the it's image id or reference. This is the
 // semantic defined in CRI now.
-func (c *criContainerdService) RemoveImage(ctx context.Context, r *runtime.RemoveImageRequest) (retRes *runtime.RemoveImageResponse, retErr error) {
-	glog.V(2).Infof("RemoveImage %q", r.GetImage().GetImage())
-	defer func() {
-		if retErr == nil {
-			glog.V(2).Infof("RemoveImage %q returns successfully", r.GetImage().GetImage())
-		}
-	}()
+func (c *criContainerdService) RemoveImage(ctx context.Context, r *runtime.RemoveImageRequest) (*runtime.RemoveImageResponse, error) {
 	image, err := c.localResolve(ctx, r.GetImage().GetImage())
 	if err != nil {
 		return nil, fmt.Errorf("can not resolve %q locally: %v", r.GetImage().GetImage(), err)

--- a/pkg/server/image_status.go
+++ b/pkg/server/image_status.go
@@ -19,7 +19,6 @@ package server
 import (
 	"fmt"
 
-	"github.com/golang/glog"
 	"golang.org/x/net/context"
 	"k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
 )
@@ -27,14 +26,7 @@ import (
 // ImageStatus returns the status of the image, returns nil if the image isn't present.
 // TODO(random-liu): We should change CRI to distinguish image id and image spec. (See
 // kubernetes/kubernetes#46255)
-func (c *criContainerdService) ImageStatus(ctx context.Context, r *runtime.ImageStatusRequest) (retRes *runtime.ImageStatusResponse, retErr error) {
-	glog.V(5).Infof("ImageStatus for image %q", r.GetImage().GetImage())
-	defer func() {
-		if retErr == nil {
-			glog.V(5).Infof("ImageStatus for %q returns image status %+v",
-				r.GetImage().GetImage(), retRes.GetImage())
-		}
-	}()
+func (c *criContainerdService) ImageStatus(ctx context.Context, r *runtime.ImageStatusRequest) (*runtime.ImageStatusResponse, error) {
 	image, err := c.localResolve(ctx, r.GetImage().GetImage())
 	if err != nil {
 		return nil, fmt.Errorf("can not resolve %q locally: %v", r.GetImage().GetImage(), err)

--- a/pkg/server/instrumented_service.go
+++ b/pkg/server/instrumented_service.go
@@ -1,0 +1,282 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"github.com/golang/glog"
+	"golang.org/x/net/context"
+	"k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
+)
+
+// instrumentedService wraps service and logs each operation.
+type instrumentedService struct {
+	*criContainerdService
+}
+
+func newInstrumentedService(c *criContainerdService) CRIContainerdService {
+	return &instrumentedService{criContainerdService: c}
+}
+
+func (in *instrumentedService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandboxRequest) (res *runtime.RunPodSandboxResponse, err error) {
+	glog.V(2).Infof("RunPodSandbox with config %+v", r.GetConfig())
+	defer func() {
+		if err != nil {
+			glog.Errorf("RunPodSandbox for %+v failed, error: %v", r.GetConfig().GetMetadata(), err)
+		} else {
+			glog.V(2).Infof("RunPodSandbox for %+v returns sandbox id %q", r.GetConfig().GetMetadata(), res.GetPodSandboxId())
+		}
+	}()
+	return in.criContainerdService.RunPodSandbox(ctx, r)
+}
+
+func (in *instrumentedService) ListPodSandbox(ctx context.Context, r *runtime.ListPodSandboxRequest) (res *runtime.ListPodSandboxResponse, err error) {
+	glog.V(5).Infof("ListPodSandbox with filter %+v", r.GetFilter())
+	defer func() {
+		if err != nil {
+			glog.Errorf("ListPodSandbox failed, error: %v", err)
+		} else {
+			glog.V(5).Infof("ListPodSandbox returns sandboxes %+v", res.GetItems())
+		}
+	}()
+	return in.criContainerdService.ListPodSandbox(ctx, r)
+}
+
+func (in *instrumentedService) PodSandboxStatus(ctx context.Context, r *runtime.PodSandboxStatusRequest) (res *runtime.PodSandboxStatusResponse, err error) {
+	glog.V(5).Infof("PodSandboxStatus for %q", r.GetPodSandboxId())
+	defer func() {
+		if err != nil {
+			glog.Errorf("PodSandboxStatus for %q failed, error: %v", r.GetPodSandboxId(), err)
+		} else {
+			glog.V(5).Infof("PodSandboxStatus for %q returns status %+v", r.GetPodSandboxId(), res.GetStatus())
+		}
+	}()
+	return in.criContainerdService.PodSandboxStatus(ctx, r)
+}
+
+func (in *instrumentedService) StopPodSandbox(ctx context.Context, r *runtime.StopPodSandboxRequest) (_ *runtime.StopPodSandboxResponse, err error) {
+	glog.V(2).Infof("StopPodSandbox for %q", r.GetPodSandboxId())
+	defer func() {
+		if err != nil {
+			glog.Errorf("StopPodSandbox for %q failed, error: %v", r.GetPodSandboxId(), err)
+		} else {
+			glog.V(2).Infof("StopPodSandbox for %q returns successfully", r.GetPodSandboxId())
+		}
+	}()
+	return in.criContainerdService.StopPodSandbox(ctx, r)
+}
+
+func (in *instrumentedService) RemovePodSandbox(ctx context.Context, r *runtime.RemovePodSandboxRequest) (_ *runtime.RemovePodSandboxResponse, err error) {
+	glog.V(2).Infof("RemovePodSandbox for %q", r.GetPodSandboxId())
+	defer func() {
+		if err != nil {
+			glog.Errorf("RemovePodSandbox for %q failed, error: %v", r.GetPodSandboxId(), err)
+		} else {
+			glog.V(2).Infof("RemovePodSandbox %q returns successfully", r.GetPodSandboxId())
+		}
+	}()
+	return in.criContainerdService.RemovePodSandbox(ctx, r)
+}
+
+func (in *instrumentedService) PortForward(ctx context.Context, r *runtime.PortForwardRequest) (res *runtime.PortForwardResponse, err error) {
+	glog.V(2).Infof("Portforward for %q port %v", r.GetPodSandboxId(), r.GetPort())
+	defer func() {
+		if err != nil {
+			glog.Errorf("Portforward for %q failed, error: %v", r.GetPodSandboxId(), err)
+		} else {
+			glog.V(2).Infof("Portforward for %q returns URL %q", r.GetPodSandboxId(), res.GetUrl())
+		}
+	}()
+	return in.criContainerdService.PortForward(ctx, r)
+}
+
+func (in *instrumentedService) CreateContainer(ctx context.Context, r *runtime.CreateContainerRequest) (res *runtime.CreateContainerResponse, err error) {
+	glog.V(2).Infof("CreateContainer within sandbox %q with container config %+v and sandbox config %+v",
+		r.GetPodSandboxId(), r.GetConfig(), r.GetSandboxConfig())
+	defer func() {
+		if err != nil {
+			glog.Errorf("CreateContainer within sandbox %q for %+v failed, error: %v",
+				r.GetPodSandboxId(), r.GetConfig().GetMetadata(), err)
+		} else {
+			glog.V(2).Infof("CreateContainer within sandbox %q for %+v returns container id %q",
+				r.GetPodSandboxId(), r.GetConfig().GetMetadata(), res.GetContainerId())
+		}
+	}()
+	return in.criContainerdService.CreateContainer(ctx, r)
+}
+
+func (in *instrumentedService) StartContainer(ctx context.Context, r *runtime.StartContainerRequest) (_ *runtime.StartContainerResponse, err error) {
+	glog.V(2).Infof("StartContainer for %q", r.GetContainerId())
+	defer func() {
+		if err != nil {
+			glog.Errorf("StartContainer for %q failed, error: %v", r.GetContainerId(), err)
+		} else {
+			glog.V(2).Infof("StartContainer for %q returns successfully", r.GetContainerId())
+		}
+	}()
+	return in.criContainerdService.StartContainer(ctx, r)
+}
+
+func (in *instrumentedService) ListContainers(ctx context.Context, r *runtime.ListContainersRequest) (res *runtime.ListContainersResponse, err error) {
+	glog.V(5).Infof("ListContainers with filter %+v", r.GetFilter())
+	defer func() {
+		if err != nil {
+			glog.Errorf("ListContainers with filter %+v failed, error: %v", r.GetFilter(), err)
+		} else {
+			glog.V(5).Infof("ListContainers with filter %+v returns containers %+v",
+				r.GetFilter(), res.GetContainers())
+		}
+	}()
+	return in.criContainerdService.ListContainers(ctx, r)
+}
+
+func (in *instrumentedService) ContainerStatus(ctx context.Context, r *runtime.ContainerStatusRequest) (res *runtime.ContainerStatusResponse, err error) {
+	glog.V(5).Infof("ContainerStatus for %q", r.GetContainerId())
+	defer func() {
+		if err != nil {
+			glog.Errorf("ContainerStatus for %q failed, error: %v", r.GetContainerId(), err)
+		} else {
+			glog.V(5).Infof("ContainerStatus for %q returns status %+v", r.GetContainerId(), res.GetStatus())
+		}
+	}()
+	return in.criContainerdService.ContainerStatus(ctx, r)
+}
+
+func (in *instrumentedService) StopContainer(ctx context.Context, r *runtime.StopContainerRequest) (res *runtime.StopContainerResponse, err error) {
+	glog.V(2).Infof("StopContainer for %q with timeout %d (s)", r.GetContainerId(), r.GetTimeout())
+	defer func() {
+		if err != nil {
+			glog.Errorf("StopContainer for %q failed, error: %v", r.GetContainerId(), err)
+		} else {
+			glog.V(2).Infof("StopContainer for %q returns successfully", r.GetContainerId())
+		}
+	}()
+	return in.criContainerdService.StopContainer(ctx, r)
+}
+
+func (in *instrumentedService) RemoveContainer(ctx context.Context, r *runtime.RemoveContainerRequest) (res *runtime.RemoveContainerResponse, err error) {
+	glog.V(2).Infof("RemoveContainer for %q", r.GetContainerId())
+	defer func() {
+		if err != nil {
+			glog.Errorf("RemoveContainer for %q failed, error: %v", r.GetContainerId(), err)
+		} else {
+			glog.V(2).Infof("RemoveContainer for %q returns successfully", r.GetContainerId())
+		}
+	}()
+	return in.criContainerdService.RemoveContainer(ctx, r)
+}
+
+func (in *instrumentedService) ExecSync(ctx context.Context, r *runtime.ExecSyncRequest) (res *runtime.ExecSyncResponse, err error) {
+	glog.V(2).Infof("ExecSync for %q with command %+v and timeout %d (s)", r.GetContainerId(), r.GetCmd(), r.GetTimeout())
+	defer func() {
+		if err != nil {
+			glog.Errorf("ExecSync for %q failed, error: %v", r.GetContainerId(), err)
+		} else {
+			glog.V(2).Infof("ExecSync for %q returns with exit code %d", r.GetContainerId(), res.GetExitCode())
+			glog.V(4).Infof("ExecSync for %q outputs - stdout: %q, stderr: %q", r.GetContainerId(),
+				res.GetStdout(), res.GetStderr())
+		}
+	}()
+	return in.criContainerdService.ExecSync(ctx, r)
+}
+
+func (in *instrumentedService) Exec(ctx context.Context, r *runtime.ExecRequest) (res *runtime.ExecResponse, err error) {
+	glog.V(2).Infof("Exec for %q with command %+v, tty %v and stdin %v",
+		r.GetContainerId(), r.GetCmd(), r.GetTty(), r.GetStdin())
+	defer func() {
+		if err != nil {
+			glog.Errorf("Exec for %q failed, error: %v", r.GetContainerId(), err)
+		} else {
+			glog.V(2).Infof("Exec for %q returns URL %q", r.GetContainerId(), res.GetUrl())
+		}
+	}()
+	return in.criContainerdService.Exec(ctx, r)
+}
+
+func (in *instrumentedService) Attach(ctx context.Context, r *runtime.AttachRequest) (res *runtime.AttachResponse, err error) {
+	glog.V(2).Infof("Attach for %q with tty %v and stdin %v", r.GetContainerId(), r.GetTty(), r.GetStdin())
+	defer func() {
+		if err != nil {
+			glog.Errorf("Attach for %q failed, error: %v", r.GetContainerId(), err)
+		} else {
+			glog.V(2).Infof("Attach for %q returns URL %q", r.GetContainerId(), res.Url)
+		}
+	}()
+	return in.criContainerdService.Attach(ctx, r)
+}
+
+func (in *instrumentedService) UpdateContainerResources(ctx context.Context, r *runtime.UpdateContainerResourcesRequest) (res *runtime.UpdateContainerResourcesResponse, err error) {
+	glog.V(2).Infof("UpdateContainerResources for %q with %+v", r.GetContainerId(), r.GetLinux())
+	defer func() {
+		if err != nil {
+			glog.Errorf("UpdateContainerResources for %q failed, error: %v", r.GetContainerId(), err)
+		} else {
+			glog.V(2).Infof("UpdateContainerResources for %q returns successfully", r.GetContainerId())
+		}
+	}()
+	return in.criContainerdService.UpdateContainerResources(ctx, r)
+}
+
+func (in *instrumentedService) PullImage(ctx context.Context, r *runtime.PullImageRequest) (res *runtime.PullImageResponse, err error) {
+	glog.V(2).Infof("PullImage %q with auth config %+v", r.GetImage().GetImage(), r.GetAuth())
+	defer func() {
+		if err != nil {
+			glog.Errorf("PullImage %q failed, error: %v", r.GetImage().GetImage(), err)
+		} else {
+			glog.V(2).Infof("PullImage %q returns image reference %q",
+				r.GetImage().GetImage(), res.GetImageRef())
+		}
+	}()
+	return in.criContainerdService.PullImage(ctx, r)
+}
+
+func (in *instrumentedService) ListImages(ctx context.Context, r *runtime.ListImagesRequest) (res *runtime.ListImagesResponse, err error) {
+	glog.V(5).Infof("ListImages with filter %+v", r.GetFilter())
+	defer func() {
+		if err != nil {
+			glog.Errorf("ListImages with filter %+v failed, error: %v", r.GetFilter(), err)
+		} else {
+			glog.V(5).Infof("ListImages with filter %+v returns image list %+v",
+				r.GetFilter(), res.GetImages())
+		}
+	}()
+	return in.criContainerdService.ListImages(ctx, r)
+}
+
+func (in *instrumentedService) ImageStatus(ctx context.Context, r *runtime.ImageStatusRequest) (res *runtime.ImageStatusResponse, err error) {
+	glog.V(5).Infof("ImageStatus for %q", r.GetImage().GetImage())
+	defer func() {
+		if err != nil {
+			glog.Errorf("ImageStatus for %q failed, error: %v", r.GetImage().GetImage(), err)
+		} else {
+			glog.V(5).Infof("ImageStatus for %q returns image status %+v",
+				r.GetImage().GetImage(), res.GetImage())
+		}
+	}()
+	return in.criContainerdService.ImageStatus(ctx, r)
+}
+
+func (in *instrumentedService) RemoveImage(ctx context.Context, r *runtime.RemoveImageRequest) (_ *runtime.RemoveImageResponse, err error) {
+	glog.V(2).Infof("RemoveImage %q", r.GetImage().GetImage())
+	defer func() {
+		if err != nil {
+			glog.Errorf("RemoveImage %q failed, error: %v", r.GetImage().GetImage(), err)
+		} else {
+			glog.V(2).Infof("RemoveImage %q returns successfully", r.GetImage().GetImage())
+		}
+	}()
+	return in.criContainerdService.RemoveImage(ctx, r)
+}

--- a/pkg/server/sandbox_list.go
+++ b/pkg/server/sandbox_list.go
@@ -21,7 +21,6 @@ import (
 
 	tasks "github.com/containerd/containerd/api/services/tasks/v1"
 	"github.com/containerd/containerd/api/types/task"
-	"github.com/golang/glog"
 	"golang.org/x/net/context"
 	"k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
 
@@ -29,14 +28,7 @@ import (
 )
 
 // ListPodSandbox returns a list of Sandbox.
-func (c *criContainerdService) ListPodSandbox(ctx context.Context, r *runtime.ListPodSandboxRequest) (retRes *runtime.ListPodSandboxResponse, retErr error) {
-	glog.V(5).Infof("ListPodSandbox with filter %+v", r.GetFilter())
-	defer func() {
-		if retErr == nil {
-			glog.V(5).Infof("ListPodSandbox returns sandboxes %+v", retRes.GetItems())
-		}
-	}()
-
+func (c *criContainerdService) ListPodSandbox(ctx context.Context, r *runtime.ListPodSandboxRequest) (*runtime.ListPodSandboxResponse, error) {
 	// List all sandboxes from store.
 	sandboxesInStore := c.sandboxStore.List()
 

--- a/pkg/server/sandbox_portforward.go
+++ b/pkg/server/sandbox_portforward.go
@@ -33,13 +33,6 @@ import (
 // PortForward prepares a streaming endpoint to forward ports from a PodSandbox, and returns the address.
 func (c *criContainerdService) PortForward(ctx context.Context, r *runtime.PortForwardRequest) (retRes *runtime.PortForwardResponse, retErr error) {
 	// TODO(random-liu): Run a socat container inside the sandbox to do portforward.
-	glog.V(2).Infof("Portforward for sandbox %q port %v", r.GetPodSandboxId(), r.GetPort())
-	defer func() {
-		if retErr == nil {
-			glog.V(2).Infof("Portforward for %q returns URL %q", r.GetPodSandboxId(), retRes.GetUrl())
-		}
-	}()
-
 	sandbox, err := c.sandboxStore.Get(r.GetPodSandboxId())
 	if err != nil {
 		return nil, fmt.Errorf("failed to find sandbox: %v", err)

--- a/pkg/server/sandbox_remove.go
+++ b/pkg/server/sandbox_remove.go
@@ -30,14 +30,7 @@ import (
 
 // RemovePodSandbox removes the sandbox. If there are running containers in the
 // sandbox, they should be forcibly removed.
-func (c *criContainerdService) RemovePodSandbox(ctx context.Context, r *runtime.RemovePodSandboxRequest) (retRes *runtime.RemovePodSandboxResponse, retErr error) {
-	glog.V(2).Infof("RemovePodSandbox for sandbox %q", r.GetPodSandboxId())
-	defer func() {
-		if retErr == nil {
-			glog.V(2).Infof("RemovePodSandbox %q returns successfully", r.GetPodSandboxId())
-		}
-	}()
-
+func (c *criContainerdService) RemovePodSandbox(ctx context.Context, r *runtime.RemovePodSandboxRequest) (*runtime.RemovePodSandboxResponse, error) {
 	sandbox, err := c.sandboxStore.Get(r.GetPodSandboxId())
 	if err != nil {
 		if err != store.ErrNotExist {

--- a/pkg/server/sandbox_run.go
+++ b/pkg/server/sandbox_run.go
@@ -39,14 +39,7 @@ import (
 
 // RunPodSandbox creates and starts a pod-level sandbox. Runtimes should ensure
 // the sandbox is in ready state.
-func (c *criContainerdService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandboxRequest) (retRes *runtime.RunPodSandboxResponse, retErr error) {
-	glog.V(2).Infof("RunPodSandbox with config %+v", r.GetConfig())
-	defer func() {
-		if retErr == nil {
-			glog.V(2).Infof("RunPodSandbox returns sandbox id %q", retRes.GetPodSandboxId())
-		}
-	}()
-
+func (c *criContainerdService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandboxRequest) (_ *runtime.RunPodSandboxResponse, retErr error) {
 	config := r.GetConfig()
 
 	// Generate unique id and name for the sandbox and reserve the name.

--- a/pkg/server/sandbox_status.go
+++ b/pkg/server/sandbox_status.go
@@ -30,14 +30,7 @@ import (
 )
 
 // PodSandboxStatus returns the status of the PodSandbox.
-func (c *criContainerdService) PodSandboxStatus(ctx context.Context, r *runtime.PodSandboxStatusRequest) (retRes *runtime.PodSandboxStatusResponse, retErr error) {
-	glog.V(5).Infof("PodSandboxStatus for sandbox %q", r.GetPodSandboxId())
-	defer func() {
-		if retErr == nil {
-			glog.V(5).Infof("PodSandboxStatus for %q returns status %+v", r.GetPodSandboxId(), retRes.GetStatus())
-		}
-	}()
-
+func (c *criContainerdService) PodSandboxStatus(ctx context.Context, r *runtime.PodSandboxStatusRequest) (*runtime.PodSandboxStatusResponse, error) {
 	sandbox, err := c.sandboxStore.Get(r.GetPodSandboxId())
 	if err != nil {
 		return nil, fmt.Errorf("an error occurred when try to find sandbox %q: %v",

--- a/pkg/server/sandbox_stop.go
+++ b/pkg/server/sandbox_stop.go
@@ -30,14 +30,7 @@ import (
 
 // StopPodSandbox stops the sandbox. If there are any running containers in the
 // sandbox, they should be forcibly terminated.
-func (c *criContainerdService) StopPodSandbox(ctx context.Context, r *runtime.StopPodSandboxRequest) (retRes *runtime.StopPodSandboxResponse, retErr error) {
-	glog.V(2).Infof("StopPodSandbox for sandbox %q", r.GetPodSandboxId())
-	defer func() {
-		if retErr == nil {
-			glog.V(2).Infof("StopPodSandbox %q returns successfully", r.GetPodSandboxId())
-		}
-	}()
-
+func (c *criContainerdService) StopPodSandbox(ctx context.Context, r *runtime.StopPodSandboxRequest) (*runtime.StopPodSandboxResponse, error) {
 	sandbox, err := c.sandboxStore.Get(r.GetPodSandboxId())
 	if err != nil {
 		return nil, fmt.Errorf("an error occurred when try to find sandbox %q: %v",

--- a/pkg/server/service.go
+++ b/pkg/server/service.go
@@ -127,7 +127,7 @@ func NewCRIContainerdService(containerdEndpoint, rootDir, networkPluginBinDir, n
 		return nil, fmt.Errorf("failed to create stream server: %v", err)
 	}
 
-	return c, nil
+	return newInstrumentedService(c), nil
 }
 
 func (c *criContainerdService) Start() {

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 
 	"golang.org/x/net/context"
-
 	"k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
 )
 

--- a/pkg/server/version.go
+++ b/pkg/server/version.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 
 	"golang.org/x/net/context"
-
 	"k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
 )
 


### PR DESCRIPTION
Move all grpc handler logs into a instrumented service, so that we don't need to care about it in the real service.

Signed-off-by: Lantao Liu <lantaol@google.com>