### PR TITLE
Fix node e2e test.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,11 +47,11 @@ jobs:
       go: 1.8.x
     - stage: E2E Test
       script:
-        - test "${TRAVIS_EVENT_TYPE}" != "cron" && exit 0
+        - test "${TRAVIS_EVENT_TYPE}" != "cron" && exit 0 || true
         - make install.deps
         - make test-e2e-node
       after_script:
         # TODO(random-liu): Upload log to GCS.
-        - test "${TRAVIS_EVENT_TYPE}" != "cron" && exit 0
+        - test "${TRAVIS_EVENT_TYPE}" != "cron" && exit 0 || true
         - cat /tmp/test-e2e-node/cri-containerd.log
       go: 1.8.x


### PR DESCRIPTION
Our first cron build fails, because the test command returns exit code 1, which travis thought the test was failing.

@kubernetes-incubator/maintainers-cri-containerd 