### PR TITLE
Vendor ocicni from upstream.

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -3,7 +3,7 @@ github.com/boltdb/bolt v1.3.0-58-ge9cf4fa
 github.com/containerd/containerd f79981c2dfe35c3bfcbdd2de9b682e8c3de904b2 
 github.com/containerd/fifo fbfb6a11ec671efbe94ad1c12c2e98773f19e1e6
 github.com/containernetworking/cni v0.6.0
-github.com/cri-o/ocicni 3bb422584a0755d73718085e0edc355619b5973e https://github.com/Random-Liu/ocicni.git
+github.com/cri-o/ocicni 0f90d35d89e9ab7e972a9edeb36b0aaffa250335
 github.com/davecgh/go-spew v1.1.0
 github.com/docker/distribution b38e5838b7b2f2ad48e06ec4b500011976080621
 github.com/docker/docker cc4da8112814cdbb00dbf23370f9ed764383de1f

--- a/vendor/github.com/cri-o/ocicni/ocicni.go
+++ b/vendor/github.com/cri-o/ocicni/ocicni.go
@@ -166,6 +166,7 @@ func getDefaultCNINetwork(pluginDir string, cniDirs []string, vendorCNIDirPrefix
 			logrus.Warningf("CNI config list %s has no networks, skipping", confFile)
 			continue
 		}
+		logrus.Infof("CNI network %s (type=%v) is used from %s", confList.Name, confList.Plugins[0].Network.Type, confFile)
 		// Search for vendor-specific plugins as well as default plugins in the CNI codebase.
 		vendorDir := vendorCNIDir(vendorCNIDirPrefix, confList.Plugins[0].Network.Type)
 		cninet := &libcni.CNIConfig{
@@ -292,7 +293,7 @@ func (network *cniNetwork) addToNetwork(podNetwork PodNetwork) (cnitypes.Result,
 	}
 
 	netconf, cninet := network.NetworkConfig, network.CNIConfig
-	logrus.Infof("About to add CNI network %v (type=%v)", netconf.Name, netconf.Plugins[0].Network.Type)
+	logrus.Infof("About to add CNI network %s (type=%v)", netconf.Name, netconf.Plugins[0].Network.Type)
 	res, err := cninet.AddNetworkList(netconf, rt)
 	if err != nil {
 		logrus.Errorf("Error adding network: %v", err)
@@ -310,7 +311,7 @@ func (network *cniNetwork) deleteFromNetwork(podNetwork PodNetwork) error {
 	}
 
 	netconf, cninet := network.NetworkConfig, network.CNIConfig
-	logrus.Infof("About to del CNI network %v (type=%v)", netconf.Name, netconf.Plugins[0].Network.Type)
+	logrus.Infof("About to del CNI network %s (type=%v)", netconf.Name, netconf.Plugins[0].Network.Type)
 	err = cninet.DelNetworkList(netconf, rt)
 	if err != nil {
 		logrus.Errorf("Error deleting network: %v", err)


### PR DESCRIPTION
Fixes https://github.com/kubernetes-incubator/cri-containerd/issues/158.

Vendor ocicni from upstream, cri-o/ocicni#1 is merged.
Signed-off-by: Lantao Liu <lantaol@google.com>