### PR TITLE
Get CreatedAt from containerd instead of maintaining it ourselves.

### DIFF
--- a/pkg/server/sandbox_list.go
+++ b/pkg/server/sandbox_list.go
@@ -18,6 +18,7 @@ package server
 
 import (
 	"fmt"
+	"time"
 
 	tasks "github.com/containerd/containerd/api/services/tasks/v1"
 	"github.com/containerd/containerd/api/types/task"
@@ -54,7 +55,8 @@ func (c *criContainerdService) ListPodSandbox(ctx context.Context, r *runtime.Li
 			state = runtime.PodSandboxState_SANDBOX_READY
 		}
 
-		sandboxes = append(sandboxes, toCRISandbox(sandboxInStore.Metadata, state))
+		createdAt := sandboxInStore.Container.Info().CreatedAt
+		sandboxes = append(sandboxes, toCRISandbox(sandboxInStore.Metadata, state, createdAt))
 	}
 
 	sandboxes = c.filterCRISandboxes(sandboxes, r.GetFilter())
@@ -62,12 +64,12 @@ func (c *criContainerdService) ListPodSandbox(ctx context.Context, r *runtime.Li
 }
 
 // toCRISandbox converts sandbox metadata into CRI pod sandbox.
-func toCRISandbox(meta sandboxstore.Metadata, state runtime.PodSandboxState) *runtime.PodSandbox {
+func toCRISandbox(meta sandboxstore.Metadata, state runtime.PodSandboxState, createdAt time.Time) *runtime.PodSandbox {
 	return &runtime.PodSandbox{
 		Id:          meta.ID,
 		Metadata:    meta.Config.GetMetadata(),
 		State:       state,
-		CreatedAt:   meta.CreatedAt,
+		CreatedAt:   createdAt.UnixNano(),
 		Labels:      meta.Config.GetLabels(),
 		Annotations: meta.Config.GetAnnotations(),
 	}

--- a/pkg/server/sandbox_list_test.go
+++ b/pkg/server/sandbox_list_test.go
@@ -37,12 +37,11 @@ func TestToCRISandbox(t *testing.T) {
 		Labels:      map[string]string{"a": "b"},
 		Annotations: map[string]string{"c": "d"},
 	}
-	createdAt := time.Now().UnixNano()
+	createdAt := time.Now()
 	meta := sandboxstore.Metadata{
 		ID:        "test-id",
 		Name:      "test-name",
 		Config:    config,
-		CreatedAt: createdAt,
 		NetNSPath: "test-netns",
 	}
 	state := runtime.PodSandboxState_SANDBOX_READY
@@ -50,11 +49,11 @@ func TestToCRISandbox(t *testing.T) {
 		Id:          "test-id",
 		Metadata:    config.GetMetadata(),
 		State:       state,
-		CreatedAt:   createdAt,
+		CreatedAt:   createdAt.UnixNano(),
 		Labels:      config.GetLabels(),
 		Annotations: config.GetAnnotations(),
 	}
-	s := toCRISandbox(meta, state)
+	s := toCRISandbox(meta, state, createdAt)
 	assert.Equal(t, expect, s)
 }
 

--- a/pkg/server/sandbox_run.go
+++ b/pkg/server/sandbox_run.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/containerd/containerd"
 	"github.com/cri-o/ocicni"
@@ -123,9 +122,7 @@ func (c *criContainerdService) RunPodSandbox(ctx context.Context, r *runtime.Run
 	// Actually the Pid, NetNS and CreatedAt underlying are not included here.
 	// I'm fine with this for now. After this PR is merged, we could:
 	// 1.Get Pid from containerd, so that we don't need to checkpoint it ourselves;
-	// 2.Use permanent NetNS after #138 is merged, so that we'll have network namespace here;
-	// 3.Get CreatedAt from containerd, which have been checkpointed by containerd
-	// https://github.com/containerd/containerd/blob/master/containers/containers.go#L14.
+	// 2.Use permanent NetNS after #138 is merged, so that we'll have network namespace here.
 	metaBytes, err := sandbox.Metadata.Encode()
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert sandbox metadata: %+v, %v", sandbox.Metadata, err)
@@ -204,7 +201,6 @@ func (c *criContainerdService) RunPodSandbox(ctx context.Context, r *runtime.Run
 	}
 
 	// Add sandbox into sandbox store.
-	sandbox.CreatedAt = time.Now().UnixNano()
 	sandbox.Container = container
 	if err := c.sandboxStore.Add(sandbox); err != nil {
 		return nil, fmt.Errorf("failed to add sandbox %+v into store: %v", sandbox, err)

--- a/pkg/server/sandbox_status_test.go
+++ b/pkg/server/sandbox_status_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
+
+	sandboxstore "github.com/kubernetes-incubator/cri-containerd/pkg/store/sandbox"
+)
+
+func TestPodSandboxStatus(t *testing.T) {
+	const (
+		id = "test-id"
+		ip = "10.10.10.10"
+	)
+	createdAt := time.Now()
+	config := &runtime.PodSandboxConfig{
+		Metadata: &runtime.PodSandboxMetadata{
+			Name:      "test-name",
+			Uid:       "test-uid",
+			Namespace: "test-ns",
+			Attempt:   1,
+		},
+		Linux: &runtime.LinuxPodSandboxConfig{
+			SecurityContext: &runtime.LinuxSandboxSecurityContext{
+				NamespaceOptions: &runtime.NamespaceOption{
+					HostNetwork: true,
+					HostPid:     false,
+					HostIpc:     true,
+				},
+			},
+		},
+		Labels:      map[string]string{"a": "b"},
+		Annotations: map[string]string{"c": "d"},
+	}
+	sandbox := &sandboxstore.Sandbox{
+		Metadata: sandboxstore.Metadata{
+			ID:     id,
+			Name:   "test-name",
+			Config: config,
+		},
+	}
+	state := runtime.PodSandboxState_SANDBOX_NOTREADY
+
+	expected := &runtime.PodSandboxStatus{
+		Id:        id,
+		Metadata:  config.GetMetadata(),
+		State:     state,
+		CreatedAt: createdAt.UnixNano(),
+		Network:   &runtime.PodSandboxNetworkStatus{Ip: ip},
+		Linux: &runtime.LinuxPodSandboxStatus{
+			Namespaces: &runtime.Namespace{
+				Options: &runtime.NamespaceOption{
+					HostNetwork: true,
+					HostPid:     false,
+					HostIpc:     true,
+				},
+			},
+		},
+		Labels:      config.GetLabels(),
+		Annotations: config.GetAnnotations(),
+	}
+
+	got := toCRISandboxStatus(sandbox.Metadata, state, createdAt, ip)
+	assert.Equal(t, expected, got)
+}

--- a/pkg/store/sandbox/metadata.go
+++ b/pkg/store/sandbox/metadata.go
@@ -46,9 +46,6 @@ type Metadata struct {
 	Name string
 	// Config is the CRI sandbox config.
 	Config *runtime.PodSandboxConfig
-	// CreatedAt is the created timestamp.
-	// TODO(random-liu): Use containerd container CreatedAt (containerd#933)
-	CreatedAt int64
 	// Pid is the process id of the sandbox.
 	Pid uint32
 	// NetNSPath is the network namespace used by the sandbox.

--- a/pkg/store/sandbox/metadata_test.go
+++ b/pkg/store/sandbox/metadata_test.go
@@ -19,7 +19,6 @@ package sandbox
 import (
 	"encoding/json"
 	"testing"
-	"time"
 
 	assertlib "github.com/stretchr/testify/assert"
 	"k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
@@ -37,7 +36,6 @@ func TestMetadataEncodeDecode(t *testing.T) {
 				Attempt:   1,
 			},
 		},
-		CreatedAt: time.Now().UnixNano(),
 	}
 	assert := assertlib.New(t)
 	data, err := meta.Encode()

--- a/pkg/store/sandbox/sandbox_test.go
+++ b/pkg/store/sandbox/sandbox_test.go
@@ -18,7 +18,6 @@ package sandbox
 
 import (
 	"testing"
-	"time"
 
 	assertlib "github.com/stretchr/testify/assert"
 	"k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
@@ -40,7 +39,6 @@ func TestSandboxStore(t *testing.T) {
 					Attempt:   1,
 				},
 			},
-			CreatedAt: time.Now().UnixNano(),
 			Pid:       1001,
 			NetNSPath: "TestNetNS-1",
 		},
@@ -55,7 +53,6 @@ func TestSandboxStore(t *testing.T) {
 					Attempt:   2,
 				},
 			},
-			CreatedAt: time.Now().UnixNano(),
 			Pid:       1002,
 			NetNSPath: "TestNetNS-2",
 		},
@@ -70,7 +67,6 @@ func TestSandboxStore(t *testing.T) {
 					Attempt:   3,
 				},
 			},
-			CreatedAt: time.Now().UnixNano(),
 			Pid:       1003,
 			NetNSPath: "TestNetNS-3",
 		},


### PR DESCRIPTION
Addresses a TODO.

Ref https://github.com/kubernetes-incubator/cri-containerd/pull/156#discussion_r134677176. /cc @yanxuean 

Signed-off-by: Lantao Liu <lantaol@google.com>