### PR TITLE
Not printing any log for node e2e.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,8 +50,5 @@ jobs:
         - test "${TRAVIS_EVENT_TYPE}" != "cron" && exit 0 || true
         - make install.deps
         - make test-e2e-node
-      after_script:
         # TODO(random-liu): Upload log to GCS.
-        - test "${TRAVIS_EVENT_TYPE}" != "cron" && exit 0 || true
-        - cat /tmp/test-e2e-node/cri-containerd.log
       go: 1.8.x


### PR DESCRIPTION
Latest node e2e failed again because log is too long. Since currently, node e2e is only best effort, let's not print any log for it, just show the test result.

https://travis-ci.org/kubernetes-incubator/cri-containerd/jobs/267875959

If we are going to debug a test failure, we need to reproduce it ourselves. I'll try to set up a node e2e test in Kubernetes test infra as soon as possible.

Signed-off-by: Lantao Liu <lantaol@google.com>