### PR TITLE
Do not checkpoint sandbox pid.

### DIFF
--- a/pkg/server/sandbox_portforward.go
+++ b/pkg/server/sandbox_portforward.go
@@ -40,7 +40,7 @@ func (c *criContainerdService) PortForward(ctx context.Context, r *runtime.PortF
 
 	t, err := sandbox.Container.Task(ctx, nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get sandbox container: %v", err)
+		return nil, fmt.Errorf("failed to get sandbox container task: %v", err)
 	}
 	status, err := t.Status(ctx)
 	if err != nil {
@@ -61,7 +61,11 @@ func (c *criContainerdService) portForward(id string, port int32, stream io.Read
 	if err != nil {
 		return fmt.Errorf("failed to find sandbox in store: %v", err)
 	}
-	pid := s.Pid
+	t, err := s.Container.Task(context.Background(), nil)
+	if err != nil {
+		return fmt.Errorf("failed to get sandbox container task: %v", err)
+	}
+	pid := t.Pid()
 
 	socat, err := exec.LookPath("socat")
 	if err != nil {

--- a/pkg/server/sandbox_run.go
+++ b/pkg/server/sandbox_run.go
@@ -118,11 +118,6 @@ func (c *criContainerdService) RunPodSandbox(ctx context.Context, r *runtime.Run
 	glog.V(4).Infof("Sandbox container spec: %+v", spec)
 
 	// Checkpoint metadata into container
-	// TODO(random-liu): Switch to extensions(after merge containerd #1378).
-	// Actually the Pid, NetNS and CreatedAt underlying are not included here.
-	// I'm fine with this for now. After this PR is merged, we could:
-	// 1.Get Pid from containerd, so that we don't need to checkpoint it ourselves;
-	// 2.Use permanent NetNS after #138 is merged, so that we'll have network namespace here.
 	metaBytes, err := sandbox.Metadata.Encode()
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert sandbox metadata: %+v, %v", sandbox.Metadata, err)
@@ -194,7 +189,6 @@ func (c *criContainerdService) RunPodSandbox(ctx context.Context, r *runtime.Run
 		}
 	}()
 
-	sandbox.Pid = task.Pid()
 	if err = task.Start(ctx); err != nil {
 		return nil, fmt.Errorf("failed to start sandbox container task %q: %v",
 			id, err)

--- a/pkg/store/sandbox/metadata.go
+++ b/pkg/store/sandbox/metadata.go
@@ -46,8 +46,6 @@ type Metadata struct {
 	Name string
 	// Config is the CRI sandbox config.
 	Config *runtime.PodSandboxConfig
-	// Pid is the process id of the sandbox.
-	Pid uint32
 	// NetNSPath is the network namespace used by the sandbox.
 	NetNSPath string
 }

--- a/pkg/store/sandbox/sandbox_test.go
+++ b/pkg/store/sandbox/sandbox_test.go
@@ -39,7 +39,6 @@ func TestSandboxStore(t *testing.T) {
 					Attempt:   1,
 				},
 			},
-			Pid:       1001,
 			NetNSPath: "TestNetNS-1",
 		},
 		"2": {
@@ -53,7 +52,6 @@ func TestSandboxStore(t *testing.T) {
 					Attempt:   2,
 				},
 			},
-			Pid:       1002,
 			NetNSPath: "TestNetNS-2",
 		},
 		"3": {
@@ -67,7 +65,6 @@ func TestSandboxStore(t *testing.T) {
 					Attempt:   3,
 				},
 			},
-			Pid:       1003,
 			NetNSPath: "TestNetNS-3",
 		},
 	}


### PR DESCRIPTION
Address TODOs added in https://github.com/kubernetes-incubator/cri-containerd/pull/156.

* On one hand, we don't need to checkpoint sandbox pid, because we use sandbox when it's running, and we'll always be able to its pid from containerd.
* On the other hand, if we want to use containerd label to checkpoint sandbox pid, we have to update the label. Because we usually create label when create container, but we'll only be able to get pid after start task.

/cc @yanxuean 

Signed-off-by: Lantao Liu <lantaol@google.com>