### PR TITLE
Use rbind and rprivate in bind mount.

### DIFF
--- a/hack/test-e2e-node.sh
+++ b/hack/test-e2e-node.sh
@@ -19,13 +19,9 @@ set -o pipefail
 source $(dirname "${BASH_SOURCE[0]}")/test-utils.sh
 
 DEFAULT_SKIP="\[Flaky\]|\[Slow\]|\[Serial\]"
-DEFAULT_SKIP+="|scheduling\sa\sGuaranteed\sPod"
-DEFAULT_SKIP+="|scheduling\sa\sBurstable\sPod"
-DEFAULT_SKIP+="|scheduling\sa\sBestEffort\sPod"
 DEFAULT_SKIP+="|querying\s\/stats\/summary"
 DEFAULT_SKIP+="|set\sto\sthe\smanifest\sdigest"
 DEFAULT_SKIP+="|AppArmor"
-DEFAULT_SKIP+="|Top\slevel\sQoS\scontainers"
 DEFAULT_SKIP+="|pull\sfrom\sprivate\sregistry\swith\ssecret"
 
 # FOCUS focuses the test to run.
@@ -54,6 +50,10 @@ git checkout ${KUBERNETES_VERSION}
 mkdir -p ${REPORT_DIR}
 start_cri_containerd ${REPORT_DIR}
 
-make test-e2e-node RUNTIME=remote CONTAINER_RUNTIME_ENDPOINT=unix:///var/run/cri-containerd.sock ARTIFACTS=${REPORT_DIR}
+make test-e2e-node \
+	RUNTIME=remote \
+	CONTAINER_RUNTIME_ENDPOINT=unix:///var/run/cri-containerd.sock \
+	ARTIFACTS=${REPORT_DIR} \
+	TEST_ARGS='--kubelet-flags=--cgroups-per-qos=true --kubelet-flags=--cgroup-root=/' # Enable the QOS tree.
 
 kill_cri_containerd

--- a/pkg/server/container_create.go
+++ b/pkg/server/container_create.go
@@ -438,9 +438,11 @@ func addOCIBindMounts(g *generate.Generator, mounts []*runtime.Mount) {
 	for _, mount := range mounts {
 		dst := mount.GetContainerPath()
 		src := mount.GetHostPath()
-		options := []string{"rw"}
+		options := []string{"rbind", "rprivate"}
 		if mount.GetReadonly() {
-			options = []string{"ro"}
+			options = append(options, "ro")
+		} else {
+			options = append(options, "rw")
 		}
 		// TODO(random-liu): [P1] Apply selinux label
 		g.AddBindMount(src, dst, options)

--- a/pkg/server/container_create_test.go
+++ b/pkg/server/container_create_test.go
@@ -121,8 +121,8 @@ func getCreateContainerTestData() (*runtime.ContainerConfig, *runtime.PodSandbox
 		checkMount(t, spec.Mounts, "cgroup", "/sys/fs/cgroup", "cgroup", []string{"ro"}, nil)
 
 		t.Logf("Check bind mount")
-		checkMount(t, spec.Mounts, "host-path-1", "container-path-1", "bind", []string{"rw"}, nil)
-		checkMount(t, spec.Mounts, "host-path-2", "container-path-2", "bind", []string{"ro"}, nil)
+		checkMount(t, spec.Mounts, "host-path-1", "container-path-1", "bind", []string{"rbind", "rprivate", "rw"}, nil)
+		checkMount(t, spec.Mounts, "host-path-2", "container-path-2", "bind", []string{"rbind", "rprivate", "ro"}, nil)
 
 		t.Logf("Check resource limits")
 		assert.EqualValues(t, *spec.Linux.Resources.CPU.Period, 100)


### PR DESCRIPTION
Use `rbind` and `rpivate` option for bind mount.

The QoS test mount host cgroup inside the container, and check whether QoS cgroups are created as expected. Without `rbind`, this won't work.

Now with this PR we could run QoS test.

Also ref https://github.com/kubernetes-incubator/cri-containerd/issues/185.

Signed-off-by: Lantao Liu <lantaol@google.com>