### PR TITLE
Fix sandbox container snapshotter.

### DIFF
--- a/cmd/cri-containerd/cri_containerd.go
+++ b/cmd/cri-containerd/cri_containerd.go
@@ -40,6 +40,7 @@ func main() {
 	glog.V(2).Infof("Run cri-containerd grpc server on socket %q", o.SocketPath)
 	service, err := server.NewCRIContainerdService(
 		o.ContainerdEndpoint,
+		o.ContainerdSnapshotter,
 		o.RootDir,
 		o.NetworkPluginBinDir,
 		o.NetworkPluginConfDir,

--- a/cmd/cri-containerd/options/options.go
+++ b/cmd/cri-containerd/options/options.go
@@ -18,8 +18,8 @@ package options
 
 import (
 	"flag"
-	"time"
 
+	"github.com/containerd/containerd"
 	"github.com/spf13/pflag"
 )
 
@@ -34,8 +34,8 @@ type CRIContainerdOptions struct {
 	PrintVersion bool
 	// ContainerdEndpoint is the containerd endpoint path.
 	ContainerdEndpoint string
-	// ContainerdConnectionTimeout is the connection timeout for containerd client.
-	ContainerdConnectionTimeout time.Duration
+	// ContainerdSnapshotter is the snapshotter used by containerd.
+	ContainerdSnapshotter string
 	// NetworkPluginBinDir is the directory in which the binaries for the plugin is kept.
 	NetworkPluginBinDir string
 	// NetworkPluginConfDir is the directory in which the admin places a CNI conf.
@@ -59,8 +59,8 @@ func (c *CRIContainerdOptions) AddFlags(fs *pflag.FlagSet) {
 		"/var/lib/cri-containerd", "Root directory path for cri-containerd managed files (metadata checkpoint etc).")
 	fs.StringVar(&c.ContainerdEndpoint, "containerd-endpoint",
 		"/run/containerd/containerd.sock", "Path to the containerd endpoint.")
-	fs.DurationVar(&c.ContainerdConnectionTimeout, "containerd-connection-timeout",
-		2*time.Minute, "Connection timeout for containerd client.")
+	fs.StringVar(&c.ContainerdSnapshotter, "containerd-snapshotter",
+		containerd.DefaultSnapshotter, "Snapshotter used by containerd.")
 	fs.BoolVar(&c.PrintVersion, "version",
 		false, "Print cri-containerd version information and quit.")
 	fs.StringVar(&c.NetworkPluginBinDir, "network-bin-dir",

--- a/pkg/server/container_create.go
+++ b/pkg/server/container_create.go
@@ -92,7 +92,10 @@ func (c *criContainerdService) CreateContainer(ctx context.Context, r *runtime.C
 	}
 	glog.V(4).Infof("Container spec: %+v", spec)
 
-	var opts []containerd.NewContainerOpts
+	// Set snapshotter before any other options.
+	opts := []containerd.NewContainerOpts{
+		containerd.WithSnapshotter(c.snapshotter),
+	}
 	// Prepare container rootfs.
 	if config.GetLinux().GetSecurityContext().GetReadonlyRootfs() {
 		opts = append(opts, containerd.WithNewSnapshotView(id, image.Image))

--- a/pkg/server/image_pull.go
+++ b/pkg/server/image_pull.go
@@ -91,7 +91,12 @@ func (c *criContainerdService) PullImage(ctx context.Context, r *runtime.PullIma
 	})
 
 	// TODO(mikebrow): add truncIndex for image id
-	image, err := c.client.Pull(ctx, ref, containerd.WithPullUnpack, containerd.WithSchema1Conversion, containerd.WithResolver(resolver))
+	image, err := c.client.Pull(ctx, ref,
+		containerd.WithPullUnpack,
+		containerd.WithSchema1Conversion,
+		containerd.WithResolver(resolver),
+		containerd.WithPullSnapshotter(c.snapshotter),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to pull image %q: %v", ref, err)
 	}

--- a/pkg/server/sandbox_run.go
+++ b/pkg/server/sandbox_run.go
@@ -131,10 +131,11 @@ func (c *criContainerdService) RunPodSandbox(ctx context.Context, r *runtime.Run
 		specOpts = append(specOpts, containerd.WithUserID(uint32(uid.GetValue())))
 	}
 	opts := []containerd.NewContainerOpts{
+		containerd.WithSnapshotter(c.snapshotter),
+		containerd.WithNewSnapshotView(id, image.Image),
 		containerd.WithSpec(spec, specOpts...),
 		containerd.WithContainerLabels(labels),
-		containerd.WithRuntime(defaultRuntime),
-		containerd.WithNewSnapshotView(id, image.Image)}
+		containerd.WithRuntime(defaultRuntime)}
 	container, err := c.client.NewContainer(ctx, id, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create containerd container: %v", err)

--- a/pkg/server/service.go
+++ b/pkg/server/service.go
@@ -55,6 +55,8 @@ type criContainerdService struct {
 	// sandboxImage is the image to use for sandbox container.
 	// TODO(random-liu): Make this configurable via flag.
 	sandboxImage string
+	// snapshotter is the snapshotter to use in containerd.
+	snapshotter string
 	// sandboxStore stores all resources associated with sandboxes.
 	sandboxStore *sandboxstore.Store
 	// sandboxNameIndex stores all sandbox names and make sure each name
@@ -86,8 +88,14 @@ type criContainerdService struct {
 
 // NewCRIContainerdService returns a new instance of CRIContainerdService
 // TODO(random-liu): Add cri-containerd server config to get rid of the long arg list.
-func NewCRIContainerdService(containerdEndpoint, rootDir, networkPluginBinDir, networkPluginConfDir,
-	streamAddress, streamPort string) (CRIContainerdService, error) {
+func NewCRIContainerdService(
+	containerdEndpoint,
+	containerdSnapshotter,
+	rootDir,
+	networkPluginBinDir,
+	networkPluginConfDir,
+	streamAddress,
+	streamPort string) (CRIContainerdService, error) {
 	// TODO(random-liu): [P2] Recover from runtime state and checkpoint.
 
 	client, err := containerd.New(containerdEndpoint, containerd.WithDefaultNamespace(k8sContainerdNamespace))
@@ -99,6 +107,7 @@ func NewCRIContainerdService(containerdEndpoint, rootDir, networkPluginBinDir, n
 		os:                  osinterface.RealOS{},
 		rootDir:             rootDir,
 		sandboxImage:        defaultSandboxImage,
+		snapshotter:         containerdSnapshotter,
 		sandboxStore:        sandboxstore.NewStore(),
 		containerStore:      containerstore.NewStore(),
 		imageStore:          imagestore.NewStore(),


### PR DESCRIPTION
This PR:
1) Move `WithNewSnapshotView` before `WithUserID` to fix the failing node e2e test https://travis-ci.org/kubernetes-incubator/cri-containerd/jobs/269887455. The test specifies user id on the sandbox container, but `WithUserID` doesn't work before `WithNewSnapshotView`. (Ref https://github.com/containerd/containerd/issues/1446)
2) Make containerd snapshotter configurable, so that people could use btrfs if they want.

/cc @crosbymichael

Signed-off-by: Lantao Liu <lantaol@google.com>