### PR TITLE
Setting containerd shim to Pod cgroup

### DIFF
--- a/pkg/opts/task.go
+++ b/pkg/opts/task.go
@@ -1,0 +1,22 @@
+package opts
+
+import (
+	"context"
+
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/linux/runcopts"
+)
+
+// WithContainerdShimCgroup returns function that sets the containerd
+// shim cgroup path
+func WithContainerdShimCgroup(path string) containerd.NewTaskOpts {
+	return func(_ context.Context, _ *containerd.Client, r *containerd.TaskInfo) error {
+		r.Options = &runcopts.CreateOptions{
+			ShimCgroup: path,
+		}
+		return nil
+	}
+}
+
+//TODO: Since Options is an interface different WithXXX will be needed to set different
+// combinations of CreateOptions.

--- a/pkg/server/container_start.go
+++ b/pkg/server/container_start.go
@@ -27,6 +27,7 @@ import (
 	"golang.org/x/net/context"
 	"k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
 
+	criopts "github.com/kubernetes-incubator/cri-containerd/pkg/opts"
 	cio "github.com/kubernetes-incubator/cri-containerd/pkg/server/io"
 	containerstore "github.com/kubernetes-incubator/cri-containerd/pkg/store/container"
 )
@@ -142,8 +143,11 @@ func (c *criContainerdService) startContainer(ctx context.Context,
 		}
 		return cntr.IO, nil
 	}
-
-	task, err := container.NewTask(ctx, ioCreation)
+	var taskOpts []containerd.NewTaskOpts
+	if cgroup := sandboxConfig.GetLinux().GetCgroupParent(); cgroup != "" {
+		taskOpts = append(taskOpts, criopts.WithContainerdShimCgroup(cgroup))
+	}
+	task, err := container.NewTask(ctx, ioCreation, taskOpts...)
 	if err != nil {
 		return fmt.Errorf("failed to create containerd task: %v", err)
 	}

--- a/pkg/server/sandbox_run.go
+++ b/pkg/server/sandbox_run.go
@@ -31,6 +31,7 @@ import (
 	"golang.org/x/sys/unix"
 	"k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
 
+	criopts "github.com/kubernetes-incubator/cri-containerd/pkg/opts"
 	sandboxstore "github.com/kubernetes-incubator/cri-containerd/pkg/store/sandbox"
 	"github.com/kubernetes-incubator/cri-containerd/pkg/util"
 )
@@ -181,7 +182,11 @@ func (c *criContainerdService) RunPodSandbox(ctx context.Context, r *runtime.Run
 	glog.V(5).Infof("Create sandbox container (id=%q, name=%q).",
 		id, name)
 	// We don't need stdio for sandbox container.
-	task, err := container.NewTask(ctx, containerd.NullIO)
+	var taskOpts []containerd.NewTaskOpts
+	if cgroup := config.GetLinux().GetCgroupParent(); cgroup != "" {
+		taskOpts = append(taskOpts, criopts.WithContainerdShimCgroup(cgroup))
+	}
+	task, err := container.NewTask(ctx, containerd.NullIO, taskOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create task for sandbox %q: %v", id, err)
 	}
@@ -253,7 +258,6 @@ func (c *criContainerdService) generateSandboxContainerSpec(id string, config *r
 	// When cgroup parent is not set, containerd-shim will create container in a child cgroup
 	// of the cgroup itself is in.
 	// TODO(random-liu): [P2] Set default cgroup path if cgroup parent is not specified.
-
 	// Set namespace options.
 	securityContext := config.GetLinux().GetSecurityContext()
 	nsOptions := securityContext.GetNamespaceOptions()


### PR DESCRIPTION
Fixes #118 
Contains fix to set the cgroup for the containerd shim same as the pod cgroup.

Signed-off-by: Abhinandan Prativadi <abhi@docker.com>