### PR TITLE
Fix repo digest for schema 1 image.

### DIFF
--- a/hack/test-e2e-node.sh
+++ b/hack/test-e2e-node.sh
@@ -20,7 +20,6 @@ source $(dirname "${BASH_SOURCE[0]}")/test-utils.sh
 
 DEFAULT_SKIP="\[Flaky\]|\[Slow\]|\[Serial\]"
 DEFAULT_SKIP+="|querying\s\/stats\/summary"
-DEFAULT_SKIP+="|set\sto\sthe\smanifest\sdigest"
 DEFAULT_SKIP+="|AppArmor"
 DEFAULT_SKIP+="|pull\sfrom\sprivate\sregistry\swith\ssecret"
 


### PR DESCRIPTION
For schema1 image, we should not use it's manifest digest as pullable repo digest, because it is not pullable.

However, the current logic is wrong, because `image.Target().MediaType` has already been converted https://github.com/containerd/containerd/blob/master/remotes/docker/schema1/converter.go#L156.

We could only figure out whether the image is schema1 ourselves.

With this PR and https://github.com/kubernetes/kubernetes/pull/51775, we could pass the image digest node e2e test.

Signed-off-by: Lantao Liu <lantaol@google.com>