### PR TITLE
Make sandbox container image configurable

### DIFF
--- a/cmd/cri-containerd/cri_containerd.go
+++ b/cmd/cri-containerd/cri_containerd.go
@@ -54,6 +54,7 @@ func main() {
 		o.StreamServerAddress,
 		o.StreamServerPort,
 		o.CgroupPath,
+		o.SandboxImage,
 	)
 	if err != nil {
 		glog.Exitf("Failed to create CRI containerd service %+v: %v", o, err)

--- a/cmd/cri-containerd/options/options.go
+++ b/cmd/cri-containerd/options/options.go
@@ -48,6 +48,8 @@ type CRIContainerdOptions struct {
 	CgroupPath string
 	// EnableSelinux indicates to enable the selinux support
 	EnableSelinux bool
+	// SandboxImage is the image used by sandbox container.
+	SandboxImage string
 }
 
 // NewCRIContainerdOptions returns a reference to CRIContainerdOptions
@@ -78,6 +80,8 @@ func (c *CRIContainerdOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&c.CgroupPath, "cgroup-path", "", "The cgroup that cri-containerd is part of. By default cri-containerd is not placed in a cgroup")
 	fs.BoolVar(&c.EnableSelinux, "selinux-enabled",
 		false, "Enable selinux support.")
+	fs.StringVar(&c.SandboxImage, "sandbox-image",
+		"gcr.io/google_containers/pause:3.0", "The image used by sandbox container.")
 }
 
 // InitFlags must be called after adding all cli options flags are defined and

--- a/pkg/server/helpers.go
+++ b/pkg/server/helpers.go
@@ -57,8 +57,6 @@ const (
 )
 
 const (
-	// defaultSandboxImage is the image used by sandbox container.
-	defaultSandboxImage = "gcr.io/google_containers/pause:3.0"
 	// defaultSandboxOOMAdj is default omm adj for sandbox container. (kubernetes#47938).
 	defaultSandboxOOMAdj = -998
 	// defaultSandboxCPUshares is default cpu shares for sandbox container.

--- a/pkg/server/service.go
+++ b/pkg/server/service.go
@@ -111,7 +111,8 @@ func NewCRIContainerdService(
 	networkPluginConfDir,
 	streamAddress,
 	streamPort string,
-	cgroupPath string) (CRIContainerdService, error) {
+	cgroupPath string,
+	sandboxImage string) (CRIContainerdService, error) {
 	// TODO(random-liu): [P2] Recover from runtime state and checkpoint.
 
 	client, err := containerd.New(containerdEndpoint, containerd.WithDefaultNamespace(k8sContainerdNamespace))
@@ -129,7 +130,7 @@ func NewCRIContainerdService(
 		serverAddress:       serverAddress,
 		os:                  osinterface.RealOS{},
 		rootDir:             rootDir,
-		sandboxImage:        defaultSandboxImage,
+		sandboxImage:        sandboxImage,
 		snapshotter:         containerdSnapshotter,
 		sandboxStore:        sandboxstore.NewStore(),
 		containerStore:      containerstore.NewStore(),


### PR DESCRIPTION
The default sandbox image is `gcr.io/google_containers/pause:3.0`. However, someone may want to use another one. So make it configurable. Please refer to the issue https://github.com/kubernetes-incubator/cri-containerd/issues/191.

Signed-off-by: Jamie Zhuang <lanchongyizu@gmail.com>