### PR TITLE
Add release tarball.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,12 +29,14 @@ jobs:
         - make .gitvalidation
         - make verify
         - make binaries
+        - make release
       go: 1.8.x
     - script:
         - make install.tools
         - make .gitvalidation
         - make verify
         - make binaries
+        - make release
       go: tip
     - stage: Test
       script:

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ BUILD_DIR ?= _output
 VERSION := $(shell git describe --tags --dirty)
 # strip the first char of the tag if it's a `v`
 VERSION := $(VERSION:v%=%)
+TARBALL ?= cri-containerd-$(VERSION).tar.gz
 BUILD_TAGS:= -ldflags '-X $(PROJECT)/pkg/version.criContainerdVersion=$(VERSION)'
 SOURCES := $(shell find . -name '*.go')
 
@@ -36,6 +37,7 @@ help:
 	@echo " * 'install'        - Install binaries to system locations"
 	@echo " * 'binaries'       - Build cri-containerd"
 	@echo " * 'static-binaries - Build static cri-containerd"
+	@echo " * 'release'        - Build release tarball"
 	@echo " * 'test'           - Test cri-containerd"
 	@echo " * 'test-cri'       - Test cri-containerd with cri validation test"
 	@echo " * 'test-e2e-node'  - Test cri-containerd with Kubernetes node e2e test"
@@ -92,6 +94,11 @@ install: binaries
 uninstall:
 	rm -f $(BINDIR)/cri-containerd
 
+$(BUILD_DIR)/$(TARBALL): $(BUILD_DIR)/cri-containerd hack/versions
+	@BUILD_DIR=$(BUILD_DIR) TARBALL=$(TARBALL) ./hack/release.sh
+
+release: $(BUILD_DIR)/$(TARBALL)
+
 .PHONY: install.deps
 
 install.deps:
@@ -121,6 +128,7 @@ install.tools: .install.gitvalidation .install.gometalinter
 .PHONY: \
 	binaries \
 	static-binaries \
+	release \
 	boiler \
 	clean \
 	default \

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"/..
+cd ${ROOT}
+
+# BUILD_DIR is the directory to generate release tar.
+# TARBALL is the name of the release tar.
+BUILD_DIR=${BUILD_DIR:-"_output"}
+TARBALL=${TARBALL:-"cri-containerd.tar.gz"}
+
+destdir=${BUILD_DIR}/release-stage
+
+# Install dependencies into release stage.
+NOSUDO=true DESTDIR=${destdir} ./hack/install-deps.sh
+
+# Install cri-containerd into release stage.
+make install -e DESTDIR=${destdir}
+
+# Create release tar
+tar -zcvf ${BUILD_DIR}/${TARBALL} -C ${destdir} .


### PR DESCRIPTION
Add `make release` to:
1) Install all dependencies (containerd, runc and cni) into `_output/release-stage`;
2) Create tarball from `_output/release-stage`.

```console
$ tree _output/
_output/
├── cri-containerd
├── cri-containerd-0.1.0-158-g5ea9de0.tar.gz
└── release-stage
    ├── etc
    │   └── cni
    │       └── net.d
    │           └── 10-containerd-net.conflist
    ├── opt
    │   └── cni
    │       └── bin
    │           ├── bridge
    │           ├── dhcp
    │           ├── flannel
    │           ├── host-local
    │           ├── ipvlan
    │           ├── loopback
    │           ├── macvlan
    │           ├── portmap
    │           ├── ptp
    │           ├── sample
    │           ├── tuning
    │           └── vlan
    └── usr
        └── local
            ├── bin
            │   ├── containerd
            │   ├── containerd-shim
            │   ├── containerd-stress
            │   ├── cri-containerd
            │   └── ctr
            └── sbin
                └── runc

11 directories, 21 files
```

With the release tar ball, user could install cri-containerd and all the dependencies by simply **untar the tarball to `/`**, which is similar with golang installation.
```console
$ sudo tar -C / -xzf cri-containerd-0.1.0-158-g5ea9de0.tar.gz
```

However, we may want to consider whether we should put the CNI config inside the tarball, after @abhinandanpb figures out the cluster creation.

Signed-off-by: Lantao Liu <lantaol@google.com>