### PR TITLE
Handle environment variables which containe spaces

### DIFF
--- a/pkg/server/container_create.go
+++ b/pkg/server/container_create.go
@@ -380,7 +380,7 @@ func setOCIProcessArgs(g *generate.Generator, config *runtime.ContainerConfig, i
 // an invalid environment variable is encountered.
 func addImageEnvs(g *generate.Generator, imageEnvs []string) error {
 	for _, e := range imageEnvs {
-		kv := strings.Split(e, "=")
+		kv := strings.SplitN(e, "=", 2)
 		if len(kv) != 2 {
 			return fmt.Errorf("invalid environment variable %q", e)
 		}

--- a/pkg/server/container_create_test.go
+++ b/pkg/server/container_create_test.go
@@ -62,6 +62,8 @@ func getCreateContainerTestData() (*runtime.ContainerConfig, *runtime.PodSandbox
 		Envs: []*runtime.KeyValue{
 			{Key: "k1", Value: "v1"},
 			{Key: "k2", Value: "v2"},
+			{Key: "k3", Value: "v3=v3bis"},
+			{Key: "k4", Value: "v4=v4bis=foop"},
 		},
 		Mounts: []*runtime.Mount{
 			{
@@ -106,7 +108,7 @@ func getCreateContainerTestData() (*runtime.ContainerConfig, *runtime.PodSandbox
 		},
 	}
 	imageConfig := &imagespec.ImageConfig{
-		Env:        []string{"ik1=iv1", "ik2=iv2"},
+		Env:        []string{"ik1=iv1", "ik2=iv2", "ik3=iv3=iv3bis", "ik4=iv4=iv4bis=boop"},
 		Entrypoint: []string{"/entrypoint"},
 		Cmd:        []string{"cmd"},
 		WorkingDir: "/workspace",
@@ -115,7 +117,8 @@ func getCreateContainerTestData() (*runtime.ContainerConfig, *runtime.PodSandbox
 		assert.Equal(t, relativeRootfsPath, spec.Root.Path)
 		assert.Equal(t, []string{"test", "command", "test", "args"}, spec.Process.Args)
 		assert.Equal(t, "test-cwd", spec.Process.Cwd)
-		assert.Contains(t, spec.Process.Env, "k1=v1", "k2=v2", "ik1=iv1", "ik2=iv2")
+		assert.Contains(t, spec.Process.Env, "k1=v1", "k2=v2", "k3=v3=v3bis", "ik4=iv4=iv4bis=boop")
+		assert.Contains(t, spec.Process.Env, "ik1=iv1", "ik2=iv2", "ik3=iv3=iv3bis", "k4=v4=v4bis=foop")
 
 		t.Logf("Check cgroups bind mount")
 		checkMount(t, spec.Mounts, "cgroup", "/sys/fs/cgroup", "cgroup", []string{"ro"}, nil)


### PR DESCRIPTION
This avoids errors such as:

    spec: invalid environment variable "JAVA_OPTS=-Djava.security.egd=file:/dev/urandom"

use `SplitN(2)` to get the envvar name and value while allowing the value to
contain `=`.

Add some variables to the test data which have one or more `=` in the value.
Since this makes the resulting list of variables to check rather long split the
check in two and check the container config and image config derived values
independently.

Signed-off-by: Ian Campbell <ijc@docker.com>