### PR TITLE
Always use a writeable snapshot as the rootfs.

### DIFF
--- a/pkg/server/container_create.go
+++ b/pkg/server/container_create.go
@@ -110,12 +110,12 @@ func (c *criContainerdService) CreateContainer(ctx context.Context, r *runtime.C
 	opts := []containerd.NewContainerOpts{
 		containerd.WithSnapshotter(c.snapshotter),
 	}
-	// Prepare container rootfs.
-	if config.GetLinux().GetSecurityContext().GetReadonlyRootfs() {
-		opts = append(opts, containerd.WithNewSnapshotView(id, image.Image))
-	} else {
-		opts = append(opts, containerd.WithNewSnapshot(id, image.Image))
-	}
+	// Prepare container rootfs. This is always writeable even if
+	// the container wants a readonly rootfs since we want to give
+	// the runtime (runc) a chance to modify (e.g. to create mount
+	// points corresponding to spec.Mounts) before making the
+	// rootfs readonly (requested by spec.Root.Readonly).
+	opts = append(opts, containerd.WithNewSnapshot(id, image.Image))
 	meta.ImageRef = image.ID
 
 	// Create container root directory.

--- a/pkg/server/sandbox_run.go
+++ b/pkg/server/sandbox_run.go
@@ -132,6 +132,9 @@ func (c *criContainerdService) RunPodSandbox(ctx context.Context, r *runtime.Run
 	}
 	opts := []containerd.NewContainerOpts{
 		containerd.WithSnapshotter(c.snapshotter),
+		// A pure ro rootfs view is OK for the sandbox since
+		// we will never need to modify it or mount anything
+		// in it.
 		containerd.WithNewSnapshotView(id, image.Image),
 		containerd.WithSpec(spec, specOpts...),
 		containerd.WithContainerLabels(labels),


### PR DESCRIPTION
This will be made readonly by runc based on spec.Root.Readonly (which we
already set correctly) but defering until then gives runc the chance to make
any missing mount points as it processes the spec.Mount array.

This is necessary because many container images lack mount points for things
like the /etc/hosts which we want to overbind. This is not noticed with e.g.
Docker because it automatically creates an additional layer containing those.
This is something we may want to do here as well eventually but for now using a
writeable snapshot is both necessary and sufficient.

The same does not apply to the sandbox since we never modify its rootfs or want
to mount anything in it etc, add a comment to clarify.

Fixes #220.

Signed-off-by: Ian Campbell <ijc@docker.com>

//cc @Random-Liu 