### PR TITLE
Remove an addressed TODO.

### DIFF
--- a/pkg/server/service.go
+++ b/pkg/server/service.go
@@ -65,7 +65,6 @@ type criContainerdService struct {
 	// rootDir is the directory for managing cri-containerd files.
 	rootDir string
 	// sandboxImage is the image to use for sandbox container.
-	// TODO(random-liu): Make this configurable via flag.
 	sandboxImage string
 	// snapshotter is the snapshotter to use in containerd.
 	snapshotter string


### PR DESCRIPTION
Minor fix: Remove a TODO which has been addressed in https://github.com/kubernetes-incubator/cri-containerd/pull/207.

Simple but not urgent.

Signed-off-by: Lantao Liu <lantaol@google.com>