### PR TITLE
Run node e2e for both cron and branch update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,8 @@ jobs:
       go: 1.8.x
     - stage: E2E Test
       script:
-        - test "${TRAVIS_EVENT_TYPE}" != "cron" && exit 0 || true
+        # Skip node e2e test for pull request.
+        - test "${TRAVIS_PULL_REQUEST}" != "false" && exit 0 || true
         - make install.deps
         - UPLOAD_LOG=true make test-e2e-node
       go: 1.8.x

--- a/hack/test-e2e-node.sh
+++ b/hack/test-e2e-node.sh
@@ -74,6 +74,7 @@ make test-e2e-node \
 	CONTAINER_RUNTIME_ENDPOINT=unix:///var/run/cri-containerd.sock \
 	ARTIFACTS=${REPORT_DIR} \
 	TEST_ARGS='--kubelet-flags=--cgroups-per-qos=true --kubelet-flags=--cgroup-root=/' # Enable the QOS tree.
+test_exit_code=$?
 
 kill_cri_containerd
 
@@ -89,3 +90,5 @@ if ${UPLOAD_LOG}; then
   fi
   upload_logs_to_gcs "${UPLOAD_LOG_PATH}" "${VERSION}-$(date +%Y%m%d-%H%M%S)" "${REPORT_DIR}"
 fi
+
+exit ${test_exit_code}


### PR DESCRIPTION
Fixes: https://github.com/kubernetes-incubator/cri-containerd/issues/224

Node e2e works well. Here is the test log yesterday: http://gcsweb.k8s.io/gcs/cri-containerd_test-e2e-node/0.1.0-179-g7a75a91-20170907-084526/
Fixes https://github.com/kubernetes-incubator/cri-containerd/issues/224
This PR will enable node e2e as post-submit test, and expose the failure, so that we'll get a node e2e test result each time after a new PR is merged.

Signed-off-by: Lantao Liu <lantaol@google.com>