### PR TITLE
Ensure the mount point is propagated

### DIFF
--- a/pkg/os/os.go
+++ b/pkg/os/os.go
@@ -40,6 +40,7 @@ type OS interface {
 	WriteFile(filename string, data []byte, perm os.FileMode) error
 	Mount(source string, target string, fstype string, flags uintptr, data string) error
 	Unmount(target string, flags int) error
+	GetMounts() ([]*mount.Info, error)
 }
 
 // RealOS is used to dispatch the real system level operations.
@@ -113,4 +114,9 @@ func (RealOS) Unmount(target string, flags int) error {
 		return err
 	}
 	return unix.Unmount(target, flags)
+}
+
+// GetMounts retrieves a list of mounts for the current running process.
+func (RealOS) GetMounts() ([]*mount.Info, error) {
+	return mount.GetMounts()
 }

--- a/pkg/os/testing/fake_os.go
+++ b/pkg/os/testing/fake_os.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"sync"
 
+	"github.com/docker/docker/pkg/mount"
 	"golang.org/x/net/context"
 
 	osInterface "github.com/kubernetes-incubator/cri-containerd/pkg/os"
@@ -48,6 +49,7 @@ type FakeOS struct {
 	WriteFileFn           func(string, []byte, os.FileMode) error
 	MountFn               func(source string, target string, fstype string, flags uintptr, data string) error
 	UnmountFn             func(target string, flags int) error
+	GetMountsFn           func() ([]*mount.Info, error)
 	calls                 []CalledDetail
 	errors                map[string]error
 }
@@ -224,4 +226,17 @@ func (f *FakeOS) Unmount(target string, flags int) error {
 		return f.UnmountFn(target, flags)
 	}
 	return nil
+}
+
+// GetMounts retrieves a list of mounts for the current running process.
+func (f *FakeOS) GetMounts() ([]*mount.Info, error) {
+	f.appendCalls("GetMounts")
+	if err := f.getError("GetMounts"); err != nil {
+		return nil, err
+	}
+
+	if f.GetMountsFn != nil {
+		return f.GetMountsFn()
+	}
+	return nil, nil
 }

--- a/pkg/server/container_create.go
+++ b/pkg/server/container_create.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/contrib/apparmor"
+	"github.com/docker/docker/pkg/mount"
 	"github.com/golang/glog"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/opencontainers/runc/libcontainer/devices"
@@ -551,13 +552,24 @@ func (c *criContainerdService) addOCIBindMounts(g *generate.Generator, mounts []
 		if err != nil {
 			return fmt.Errorf("failed to resolve symlink %q: %v", src, err)
 		}
+
+		mountInfos, err := c.os.GetMounts()
+		if err != nil {
+			return err
+		}
 		options := []string{"rbind"}
 		switch mount.GetPropagation() {
 		case runtime.MountPropagation_PROPAGATION_PRIVATE:
 			options = append(options, "rprivate")
 		case runtime.MountPropagation_PROPAGATION_BIDIRECTIONAL:
+			if err := ensureShared(src, mountInfos); err != nil {
+				return err
+			}
 			options = append(options, "rshared")
 		case runtime.MountPropagation_PROPAGATION_HOST_TO_CONTAINER:
+			if err := ensureSharedOrSlave(src, mountInfos); err != nil {
+				return err
+			}
 			options = append(options, "rslave")
 		default:
 			glog.Warningf("Unknown propagation mode for hostPath %q", mount.HostPath)
@@ -695,4 +707,40 @@ func defaultRuntimeSpec() (*runtimespec.Spec, error) {
 	}
 	spec.Mounts = mounts
 	return spec, nil
+}
+
+// Ensure mount point on which path is mounted, is shared.
+func ensureShared(path string, mountInfos []*mount.Info) error {
+	sourceMount, optionalOpts, err := getSourceMount(path, mountInfos)
+	if err != nil {
+		return err
+	}
+
+	// Make sure source mount point is shared.
+	optsSplit := strings.Split(optionalOpts, " ")
+	for _, opt := range optsSplit {
+		if strings.HasPrefix(opt, "shared:") {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("path %q is mounted on %q but it is not a shared mount", path, sourceMount)
+}
+
+// Ensure mount point on which path is mounted, is either shared or slave.
+func ensureSharedOrSlave(path string, mountInfos []*mount.Info) error {
+	sourceMount, optionalOpts, err := getSourceMount(path, mountInfos)
+	if err != nil {
+		return err
+	}
+	// Make sure source mount point is shared.
+	optsSplit := strings.Split(optionalOpts, " ")
+	for _, opt := range optsSplit {
+		if strings.HasPrefix(opt, "shared:") {
+			return nil
+		} else if strings.HasPrefix(opt, "master:") {
+			return nil
+		}
+	}
+	return fmt.Errorf("path %q is mounted on %q but it is not a shared or slave mount", path, sourceMount)
 }


### PR DESCRIPTION
mount with `rshared`, the host path should be shared.
mount with `rslave`, the host pash should be shared or slave.

Based on #246 

Signed-off-by: Yanqiang Miao <miao.yanqiang@zte.com.cn>

/cc @Random-Liu 