### PR TITLE
Add systemd unit files for containerd and cri-containerd.

### DIFF
--- a/contrib/systemd-units/containerd.service
+++ b/contrib/systemd-units/containerd.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=containerd container runtime
+Documentation=https://containerd.io
+After=network.target
+
+[Service]
+Restart=always
+RestartSec=10
+ExecStart=/usr/local/bin/containerd
+Delegate=yes
+KillMode=process
+
+[Install]
+WantedBy=multi-user.target

--- a/contrib/systemd-units/cri-containerd.service
+++ b/contrib/systemd-units/cri-containerd.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Kubernetes containerd CRI shim
+Requires=network-online.target
+After=containerd.service
+
+[Service]
+Restart=always
+RestartSec=10
+ExecStart=/usr/local/bin/cri-containerd --logtostderr
+OOMScoreAdjust=-999
+
+[Install]
+WantedBy=multi-user.target

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -34,5 +34,9 @@ NOSUDO=true DESTDIR=${destdir} ./hack/install-deps.sh
 # Install cri-containerd into release stage.
 make install -e DESTDIR=${destdir}
 
+# Install systemd units into release stage.
+mkdir -p ${destdir}/etc/systemd/system
+cp ${ROOT}/contrib/systemd-units/* ${destdir}/etc/systemd/system/
+
 # Create release tar
 tar -zcvf ${BUILD_DIR}/${TARBALL} -C ${destdir} .


### PR DESCRIPTION
@abhinandanpb Feel free to keep working on your systemd setup, and update these files with yours.

This PR:
1) Add the contrib directory, which will be used to place some other useful tools for cri-containerd, e.g. systemd units, default cni config, ansible playbook (@abhinandanpb) etc.
2) Add the systemd unit files for containerd and cri-containerd, and build them into release tarball.

Signed-off-by: Lantao Liu <lantaol@google.com>