### PR TITLE
Use `WithNewSnapshot` for sandbox container.

### DIFF
--- a/pkg/server/sandbox_run.go
+++ b/pkg/server/sandbox_run.go
@@ -132,10 +132,7 @@ func (c *criContainerdService) RunPodSandbox(ctx context.Context, r *runtime.Run
 	}
 	opts := []containerd.NewContainerOpts{
 		containerd.WithSnapshotter(c.snapshotter),
-		// A pure ro rootfs view is OK for the sandbox since
-		// we will never need to modify it or mount anything
-		// in it.
-		containerd.WithNewSnapshotView(id, image.Image),
+		containerd.WithNewSnapshot(id, image.Image),
 		containerd.WithSpec(spec, specOpts...),
 		containerd.WithContainerLabels(labels),
 		containerd.WithRuntime(defaultRuntime, nil)}


### PR DESCRIPTION
See https://github.com/containerd/containerd/issues/1495.

Runc doesn't support readonly snapshot now.

Signed-off-by: Lantao Liu <lantaol@google.com>