### PR TITLE
Remove `/run` mount for backward compatibility with docker.

### DIFF
--- a/pkg/server/container_create_test.go
+++ b/pkg/server/container_create_test.go
@@ -555,3 +555,11 @@ func TestPidNamespace(t *testing.T) {
 		Type: runtimespec.PIDNamespace,
 	})
 }
+
+func TestDefaultRuntimeSpec(t *testing.T) {
+	spec, err := defaultRuntimeSpec()
+	assert.NoError(t, err)
+	for _, mount := range spec.Mounts {
+		assert.NotEqual(t, "/run", mount.Destination)
+	}
+}

--- a/pkg/server/sandbox_run.go
+++ b/pkg/server/sandbox_run.go
@@ -212,7 +212,7 @@ func (c *criContainerdService) generateSandboxContainerSpec(id string, config *r
 	imageConfig *imagespec.ImageConfig, nsPath string) (*runtimespec.Spec, error) {
 	// Creates a spec Generator with the default spec.
 	// TODO(random-liu): [P1] Compare the default settings with docker and containerd default.
-	spec, err := containerd.GenerateSpec(context.Background(), nil, nil)
+	spec, err := defaultRuntimeSpec()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
For https://github.com/containerd/containerd/issues/1494.

Remove `/run` mount because Docker doesn't do that, and there are images relying on this behavior.

In we really want to make `/run` tmpfs in the future, we may need to handle copyup.

Signed-off-by: Lantao Liu <lantaol@google.com>