### PR TITLE
kubernetes + cri-containerd + containerd installer

### DIFF
--- a/contrib/ansible/cri-containerd.yaml
+++ b/contrib/ansible/cri-containerd.yaml
@@ -1,0 +1,48 @@
+---
+- hosts: all 
+  become: true
+  tasks:
+    - include_vars: vars/vars.yaml # Contains tasks variables for installer
+    - include: tasks/bootstrap_ubuntu.yaml # Contains tasks bootstrap components for ubuntu systems 
+      when: ansible_distribution == "Ubuntu"
+    - include: tasks/bootstrap_centos.yaml # Contains tasks bootstrap components for centos systems
+      when: ansible_distribution == "CentOS"
+    - include: tasks/k8s.yaml # Contains tasks kubernetes component installation
+    - include: tasks/binaries.yaml # Contains tasks for pulling containerd and cri-containerd components
+       
+    - name: "Start Containerd"
+      systemd: name=containerd daemon_reload=yes state=started enabled=yes
+    
+    - name: "Start CRI-Containerd"
+      systemd: name=cri-containerd daemon_reload=yes state=started enabled=yes
+    
+    - name: "Set bridge-nf-call-iptables"
+      lineinfile:
+        line: "net/bridge/bridge-nf-call-iptables = 1"
+        dest: /etc/sysctl.conf
+        insertafter: 'EOF'
+        regexp: '\/net\/bridge\/bridge-nf-call-iptables = 1'
+        state: present
+      ignore_errors: true
+    
+    - name: "Check kubelet args in kubelet config"
+      shell: grep "^Environment=\"KUBELET_EXTRA_ARGS=" /etc/systemd/system/kubelet.service.d/10-kubeadm.conf 
+      ignore_errors: true
+      register: check_args
+
+    - name: "Add runtime args in kubelet conf"
+      lineinfile:
+                dest: "/etc/systemd/system/kubelet.service.d/10-kubeadm.conf"
+                line: "Environment=\"KUBELET_EXTRA_ARGS= --container-runtime=remote --runtime-request-timeout=15m --image-service-endpoint=/var/run/cri-containerd.sock --container-runtime-endpoint=/var/run/cri-containerd.sock\""
+                insertafter: '\[Service\]'
+      when: check_args.stdout == ""
+    
+    - name: "Start Kubelet"
+      systemd: name=kubelet daemon_reload=yes state=started enabled=yes
+    
+    # TODO This needs to be removed once we have consistent concurrent pull results
+    - name: "Pre-pull pause container image"
+      shell: |
+             /usr/local/bin/ctr pull gcr.io/google_containers/pause:3.0
+             /usr/local/bin/crictl --runtime-endpoint /var/run/cri-containerd.sock \
+             pull gcr.io/google_containers/pause:3.0

--- a/contrib/ansible/tasks/binaries.yaml
+++ b/contrib/ansible/tasks/binaries.yaml
@@ -1,0 +1,51 @@
+---
+- name: "Create a directory to download binaries"
+  file: path={{ cri_release_directory }} state=directory
+
+- name: "Get Containerd and CRI-Containerd"
+  get_url:
+    validate_certs: "no"
+    url: "https://storage.googleapis.com/cri-containerd-staging/cri-containerd-{{ cri_containerd_release_version }}.tar.gz"
+    dest: "{{ cri_release_directory }}"
+    mode: 0755
+
+- name: "Unpack Containerd and CRI-Containerd"
+  unarchive:
+    src: "{{ cri_release_directory }}cri-containerd-{{ cri_containerd_release_version }}.tar.gz"
+    dest: "{{ cri_release_directory }}"
+    remote_src: yes
+
+- name: "Install the containerd and cri-containerd binaries" 
+  copy:
+    src: "{{ cri_release_directory }}usr/local/bin/{{ item }}"
+    dest: "{{ local_bin_dir }}{{ item }}"
+    mode: 0755
+    remote_src: yes
+  with_items:
+    - containerd
+    - containerd-stress
+    - containerd-shim
+    - cri-containerd
+    - ctr
+    - crictl
+
+- name: "Install runc"
+  copy:    
+    src: "{{ cri_release_directory }}usr/local/sbin/{{ item }}"
+    dest: "{{ local_sbin_dir }}{{ item }}"
+    mode: 0755
+    remote_src: yes
+  with_items:
+    - runc
+
+- name: "Copy containerd systemd service unit"
+  template: src=../../systemd-units/containerd.service dest=/etc/systemd/system/containerd.service
+
+- name: "Copy cri-containerd systemd service unit"
+  template: src=../../systemd-units/cri-containerd.service dest=/etc/systemd/system/cri-containerd.service
+
+- name: "Create a directory for cni binary"
+  file: path={{ cni_bin_dir }} state=directory
+
+- name: "Create a directory for cni config files"
+  file: path={{ cni_conf_dir }} state=directory

--- a/contrib/ansible/tasks/bootstrap_centos.yaml
+++ b/contrib/ansible/tasks/bootstrap_centos.yaml
@@ -1,0 +1,13 @@
+---
+- name: "Install required packages on CentOS "
+  yum:
+    name: "{{ item }}"
+    state: latest
+    with_items:
+      - unzip
+      - tar
+      - btrfs-progs-devel
+      - libseccomp-devel
+      - util-linux 
+      - socat
+      - libselinux-python

--- a/contrib/ansible/tasks/bootstrap_ubuntu.yaml
+++ b/contrib/ansible/tasks/bootstrap_ubuntu.yaml
@@ -1,0 +1,16 @@
+---
+- name: "Install required packages on Ubuntu"
+  package:
+    name: "{{ item }}"
+    state: latest
+  with_items:
+      - unzip
+      - tar
+      - apt-transport-https
+      - btrfs-tools
+      - libapparmor-dev
+      - libseccomp-dev # Revisit the need and alternatives for all -dev packages
+      - libseccomp2
+      - socat
+      - util-linux
+# TODO: Limited support for trusty for nsenter. Need to handle/verify 

--- a/contrib/ansible/tasks/k8s.yaml
+++ b/contrib/ansible/tasks/k8s.yaml
@@ -1,0 +1,50 @@
+---
+- name: "Add gpg key (Ubuntu)"
+  apt_key:
+    url: https://packages.cloud.google.com/apt/doc/apt-key.gpg
+    state: present
+  when: ansible_distribution == "Ubuntu"
+
+- name: "Add kubernetes source list (Ubuntu)"
+  apt_repository:
+    repo: "deb http://apt.kubernetes.io/ kubernetes-{{ ansible_distribution_release }} main"
+    state: present
+    filename: "kubernetes"
+  when: ansible_distribution == "Ubuntu"
+
+- name: "Update the repository cache (Ubuntu)"
+  apt: 
+    update_cache: yes
+  when: ansible_distribution == "Ubuntu"
+
+- name: "Add Kubernetes repository and install gpg key (CentOS)"
+  yum_repository:
+    name: kubernetes
+    description: Kubernetes repository
+    baseurl: https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+    gpgcheck: yes
+    enabled: yes
+    repo_gpgcheck: yes
+    gpgkey: https://packages.cloud.google.com/yum/doc/yum-key.gpg
+  when: ansible_distribution == "CentOS"
+
+- name: "Disable SELinux (CentOS)"
+  selinux:
+    state: disabled
+  when: ansible_distribution == "CentOS"
+
+- name: "Install kubelet,kubeadm,kubectl (CentOS)"
+  yum: state=present name={{ item }}
+  with_items:
+    - kubelet
+    - kubeadm
+    - kubectl
+  when: ansible_distribution == "CentOS"
+
+- name: "Install kubelet, kubeadm, kubectl (Ubuntu)"
+  apt: name={{item}} state=installed
+  with_items:
+    - kubelet
+    - kubeadm
+    - kubectl
+  when: ansible_distribution == "Ubuntu"

--- a/contrib/ansible/vars/vars.yaml
+++ b/contrib/ansible/vars/vars.yaml
@@ -1,0 +1,8 @@
+---
+# TODO update official versions once they are available
+cri_containerd_release_version: 0.1.0-234-g55a0887 
+cri_release_directory: /opt/cri-containerd/
+local_bin_dir: /usr/local/bin/
+local_sbin_dir: /usr/local/sbin/
+cni_bin_dir: /opt/cni/bin/
+cni_conf_dir: /etc/cni/net.d/

--- a/contrib/systemd-units/containerd.service
+++ b/contrib/systemd-units/containerd.service
@@ -4,11 +4,13 @@ Documentation=https://containerd.io
 After=network.target
 
 [Service]
-Restart=always
-RestartSec=10
+ExecStartPre=/sbin/modprobe overlay
 ExecStart=/usr/local/bin/containerd
+Restart=always
+RestartSec=5
 Delegate=yes
 KillMode=process
+OOMScoreAdjust=-999
 
 [Install]
 WantedBy=multi-user.target

--- a/contrib/systemd-units/cri-containerd.service
+++ b/contrib/systemd-units/cri-containerd.service
@@ -5,7 +5,7 @@ After=containerd.service
 
 [Service]
 Restart=always
-RestartSec=10
+RestartSec=5
 ExecStart=/usr/local/bin/cri-containerd --logtostderr
 OOMScoreAdjust=-999
 


### PR DESCRIPTION
This commit contains ansible playbooks to install kubernetes, cri-containerd and containerd components as well as supporting configurations and dependencies to facilitate the usage of the kubernetes cluster with containerd.
With this change users can bring up k8 cluster in 2 steps 
1) Run the ansible playbook to install the necessary components
2) Run kubeadm init to initialize the cluster and subsequently run kubeadm join on remaining nodes
I will follow up with another PR that will have detailed set of step by step guide to install kubernetes.
There is a lot of scope for improvements and optimization. This is first cut and will gradually update the playbooks and install methods subsequently.
This has been tested on ubuntu clusters. Though the centos playbooks are attached I havent gotten a change to test it out. I believe the centos playbook is pretty similar to ubuntu dependencies but for few extra configurations which are addressed. 
The goal will be to eventually cover all the supported and tested platforms RHEL, Fedora, Sles, Linuxkit images etc. 

 
Signed-off-by: Abhinandan Prativadi <abhi@docker.com>