### PR TITLE
Create host path is mount source does not exist.

### DIFF
--- a/hack/install-deps.sh
+++ b/hack/install-deps.sh
@@ -62,20 +62,34 @@ fi
 # For multiple GOPATHs, keep the first one only
 GOPATH=${GOPATH%%:*}
 
+# checkout_repo checks out specified repository
+# and switch to specified  version.
+# Varset:
+# 1) Repo name;
+# 2) Version.
+checkout_repo() {
+  repo=$1
+  version=$2
+  path="${GOPATH}/src/${repo}"
+  if [ ! -d ${path} ]; then
+    mkdir -p ${path}
+    git clone https://${repo} ${path}
+  fi
+  cd ${path}
+  git fetch --all
+  git checkout ${version}
+}
+
 # Install runc
-go get -d ${RUNC_PKG}/...
+checkout_repo ${RUNC_PKG} ${RUNC_VERSION}
 cd ${GOPATH}/src/${RUNC_PKG}
-git fetch --all
-git checkout ${RUNC_VERSION}
 BUILDTAGS=${BUILDTAGS:-seccomp apparmor}
 make BUILDTAGS="$BUILDTAGS"
 ${sudo} make install -e DESTDIR=${RUNC_DIR}
 
 # Install cni
-go get -d ${CNI_PKG}/...
+checkout_repo ${CNI_PKG} ${CNI_VERSION}
 cd ${GOPATH}/src/${CNI_PKG}
-git fetch --all
-git checkout ${CNI_VERSION}
 ./build.sh
 ${sudo} mkdir -p ${CNI_DIR}
 ${sudo} cp -r ./bin ${CNI_DIR}
@@ -107,9 +121,7 @@ ${sudo} bash -c 'cat >'${CNI_CONFIG_DIR}'/10-containerd-net.conflist <<EOF
 EOF'
 
 # Install containerd
-go get -d ${CONTAINERD_PKG}/...
+checkout_repo ${CONTAINERD_PKG} ${CONTAINERD_VERSION}
 cd ${GOPATH}/src/${CONTAINERD_PKG}
-git fetch --all
-git checkout ${CONTAINERD_VERSION}
 make
 ${sudo} make install -e DESTDIR=${CONTAINERD_DIR}


### PR DESCRIPTION
Docker is doing this. And Kubelet is replying on this behavior.

Ref https://github.com/kubernetes/kubernetes/issues/52318.

/cc @abhinandanpb 

Signed-off-by: Lantao Liu <lantaol@google.com>