### PR TITLE
Follow symlink for mount host path.

### DIFF
--- a/pkg/server/container_create.go
+++ b/pkg/server/container_create.go
@@ -495,6 +495,12 @@ func addOCIBindMounts(g *generate.Generator, mounts []*runtime.Mount, mountLabel
 				return fmt.Errorf("failed to mkdir %q: %v", src, err)
 			}
 		}
+		// TODO(random-liu): Add cri-containerd integration test or cri validation test
+		// for this.
+		src, err := resolveSymbolicLink(src)
+		if err != nil {
+			return fmt.Errorf("failed to resolve symlink %q: %v", src, err)
+		}
 		options := []string{"rbind"}
 		switch mount.GetPropagation() {
 		case runtime.MountPropagation_PROPAGATION_PRIVATE:


### PR DESCRIPTION
This is docker's behavior, we should keep it for backward compatibility.

Also ref https://github.com/kubernetes/kubernetes/issues/52318#issuecomment-328736840.

Signed-off-by: Lantao Liu <lantaol@google.com>