### PR TITLE
Use config in service.

### DIFF
--- a/cmd/cri-containerd/cri_containerd.go
+++ b/cmd/cri-containerd/cri_containerd.go
@@ -47,18 +47,7 @@ func main() {
 	}
 
 	glog.V(2).Infof("Run cri-containerd grpc server on socket %q", o.SocketPath)
-	s, err := server.NewCRIContainerdService(
-		o.SocketPath,
-		o.ContainerdEndpoint,
-		o.ContainerdSnapshotter,
-		o.RootDir,
-		o.NetworkPluginBinDir,
-		o.NetworkPluginConfDir,
-		o.StreamServerAddress,
-		o.StreamServerPort,
-		o.CgroupPath,
-		o.SandboxImage,
-	)
+	s, err := server.NewCRIContainerdService(o.Config)
 	if err != nil {
 		glog.Exitf("Failed to create CRI containerd service %+v: %v", o, err)
 	}

--- a/pkg/server/container_create.go
+++ b/pkg/server/container_create.go
@@ -104,7 +104,7 @@ func (c *criContainerdService) CreateContainer(ctx context.Context, r *runtime.C
 	}
 
 	// Create container root directory.
-	containerRootDir := getContainerRootDir(c.rootDir, id)
+	containerRootDir := getContainerRootDir(c.config.RootDir, id)
 	if err = c.os.MkdirAll(containerRootDir, 0755); err != nil {
 		return nil, fmt.Errorf("failed to create container root directory %q: %v",
 			containerRootDir, err)
@@ -124,7 +124,7 @@ func (c *criContainerdService) CreateContainer(ctx context.Context, r *runtime.C
 	volumeMounts := c.generateVolumeMounts(containerRootDir, config.GetMounts(), image.Config)
 
 	// Generate container runtime spec.
-	mounts := c.generateContainerMounts(getSandboxRootDir(c.rootDir, sandboxID), config)
+	mounts := c.generateContainerMounts(getSandboxRootDir(c.config.RootDir, sandboxID), config)
 
 	spec, err := c.generateContainerSpec(id, sandboxPid, config, sandboxConfig, image.Config, append(mounts, volumeMounts...))
 	if err != nil {
@@ -134,7 +134,7 @@ func (c *criContainerdService) CreateContainer(ctx context.Context, r *runtime.C
 
 	// Set snapshotter before any other options.
 	opts := []containerd.NewContainerOpts{
-		containerd.WithSnapshotter(c.snapshotter),
+		containerd.WithSnapshotter(c.config.ContainerdSnapshotter),
 		// Prepare container rootfs. This is always writeable even if
 		// the container wants a readonly rootfs since we want to give
 		// the runtime (runc) a chance to modify (e.g. to create mount

--- a/pkg/server/container_remove.go
+++ b/pkg/server/container_remove.go
@@ -63,7 +63,7 @@ func (c *criContainerdService) RemoveContainer(ctx context.Context, r *runtime.R
 	// kubelet implementation, we'll never start a container once we decide to remove it,
 	// so we don't need the "Dead" state for now.
 
-	containerRootDir := getContainerRootDir(c.rootDir, id)
+	containerRootDir := getContainerRootDir(c.config.RootDir, id)
 	if err := system.EnsureRemoveAll(containerRootDir); err != nil {
 		return nil, fmt.Errorf("failed to remove container root directory %q: %v",
 			containerRootDir, err)

--- a/pkg/server/image_pull.go
+++ b/pkg/server/image_pull.go
@@ -102,7 +102,7 @@ func (c *criContainerdService) PullImage(ctx context.Context, r *runtime.PullIma
 		containerd.WithPullUnpack,
 		containerd.WithSchema1Conversion,
 		containerd.WithResolver(resolver),
-		containerd.WithPullSnapshotter(c.snapshotter),
+		containerd.WithPullSnapshotter(c.config.ContainerdSnapshotter),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to pull image %q: %v", ref, err)

--- a/pkg/server/sandbox_remove.go
+++ b/pkg/server/sandbox_remove.go
@@ -73,7 +73,7 @@ func (c *criContainerdService) RemovePodSandbox(ctx context.Context, r *runtime.
 	}
 
 	// Cleanup the sandbox root directory.
-	sandboxRootDir := getSandboxRootDir(c.rootDir, id)
+	sandboxRootDir := getSandboxRootDir(c.config.RootDir, id)
 	if err := system.EnsureRemoveAll(sandboxRootDir); err != nil {
 		return nil, fmt.Errorf("failed to remove sandbox root directory %q: %v",
 			sandboxRootDir, err)

--- a/pkg/server/sandbox_run.go
+++ b/pkg/server/sandbox_run.go
@@ -65,9 +65,9 @@ func (c *criContainerdService) RunPodSandbox(ctx context.Context, r *runtime.Run
 	}
 
 	// Ensure sandbox container image snapshot.
-	image, err := c.ensureImageExists(ctx, c.sandboxImage)
+	image, err := c.ensureImageExists(ctx, c.config.SandboxImage)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get sandbox image %q: %v", c.sandboxImage, err)
+		return nil, fmt.Errorf("failed to get sandbox image %q: %v", c.config.SandboxImage, err)
 	}
 	//Create Network Namespace if it is not in host network
 	hostNet := config.GetLinux().GetSecurityContext().GetNamespaceOptions().GetHostNetwork()
@@ -131,7 +131,7 @@ func (c *criContainerdService) RunPodSandbox(ctx context.Context, r *runtime.Run
 		specOpts = append(specOpts, containerd.WithUserID(uint32(uid.GetValue())))
 	}
 	opts := []containerd.NewContainerOpts{
-		containerd.WithSnapshotter(c.snapshotter),
+		containerd.WithSnapshotter(c.config.ContainerdSnapshotter),
 		containerd.WithNewSnapshot(id, image.Image),
 		containerd.WithSpec(spec, specOpts...),
 		containerd.WithContainerLabels(labels),
@@ -149,7 +149,7 @@ func (c *criContainerdService) RunPodSandbox(ctx context.Context, r *runtime.Run
 	}()
 
 	// Create sandbox container root directory.
-	sandboxRootDir := getSandboxRootDir(c.rootDir, id)
+	sandboxRootDir := getSandboxRootDir(c.config.RootDir, id)
 	if err := c.os.MkdirAll(sandboxRootDir, 0755); err != nil {
 		return nil, fmt.Errorf("failed to create sandbox root directory %q: %v",
 			sandboxRootDir, err)

--- a/pkg/server/sandbox_stop.go
+++ b/pkg/server/sandbox_stop.go
@@ -84,7 +84,7 @@ func (c *criContainerdService) StopPodSandbox(ctx context.Context, r *runtime.St
 
 	glog.V(2).Infof("TearDown network for sandbox %q successfully", id)
 
-	sandboxRoot := getSandboxRootDir(c.rootDir, id)
+	sandboxRoot := getSandboxRootDir(c.config.RootDir, id)
 	if err := c.unmountSandboxFiles(sandboxRoot, sandbox.Config); err != nil {
 		return nil, fmt.Errorf("failed to unmount sandbox files in %q: %v", sandboxRoot, err)
 	}

--- a/pkg/server/service_test.go
+++ b/pkg/server/service_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package server
 
 import (
+	"github.com/kubernetes-incubator/cri-containerd/cmd/cri-containerd/options"
 	ostesting "github.com/kubernetes-incubator/cri-containerd/pkg/os/testing"
 	"github.com/kubernetes-incubator/cri-containerd/pkg/registrar"
 	servertesting "github.com/kubernetes-incubator/cri-containerd/pkg/server/testing"
@@ -36,9 +37,11 @@ const (
 // newTestCRIContainerdService creates a fake criContainerdService for test.
 func newTestCRIContainerdService() *criContainerdService {
 	return &criContainerdService{
+		config: options.Config{
+			RootDir:      testRootDir,
+			SandboxImage: testSandboxImage,
+		},
 		os:                 ostesting.NewFakeOS(),
-		rootDir:            testRootDir,
-		sandboxImage:       testSandboxImage,
 		sandboxStore:       sandboxstore.NewStore(),
 		imageStore:         imagestore.NewStore(),
 		sandboxNameIndex:   registrar.NewRegistrar(),


### PR DESCRIPTION
Address a TODO, use config in service, so as to get rid of the long arg list.

Signed-off-by: Lantao Liu <lantaol@google.com>