### PR TITLE
Improve apparmor and selinux support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,10 +42,6 @@ before_script:
         gcloud auth activate-service-account --key-file gcp-secret.json --project=k8s-cri-containerd;
       fi
 
-env:
-    # Travis trusty has disabled apparmor, so disable enable in our test.
-    - CRI_CONTAINERD_FLAGS="--enable-apparmor=false"
-
 jobs:
   include:
     - stage: Build

--- a/cmd/cri-containerd/options/options.go
+++ b/cmd/cri-containerd/options/options.go
@@ -64,9 +64,6 @@ type Config struct {
 	CgroupPath string `toml:"cgroup_path"`
 	// EnableSelinux indicates to enable the selinux support.
 	EnableSelinux bool `toml:"enable_selinux"`
-	// EnableAppArmor indicates to enable apparmor support. cri-containerd will
-	// apply default apparmor profile if apparmor is enabled.
-	EnableAppArmor bool `toml:"enable_apparmor"`
 	// SandboxImage is the image used by sandbox container.
 	SandboxImage string `toml:"sandbox_image"`
 }
@@ -114,8 +111,6 @@ func (c *CRIContainerdOptions) AddFlags(fs *pflag.FlagSet) {
 		"", "The cgroup that cri-containerd is part of. By default cri-containerd is not placed in a cgroup.")
 	fs.BoolVar(&c.EnableSelinux, "enable-selinux",
 		false, "Enable selinux support.")
-	fs.BoolVar(&c.EnableAppArmor, "enable-apparmor",
-		true, "Enable apparmor support. cri-containerd will apply default apparmor profile when apparmor is enabled.")
 	fs.StringVar(&c.SandboxImage, "sandbox-image",
 		"gcr.io/google_containers/pause:3.0", "The image used by sandbox container.")
 	fs.BoolVar(&c.PrintDefaultConfig, "default-config",

--- a/vendor/github.com/opencontainers/runc/libcontainer/apparmor/apparmor.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/apparmor/apparmor.go
@@ -1,0 +1,39 @@
+// +build apparmor,linux
+
+package apparmor
+
+// #cgo LDFLAGS: -lapparmor
+// #include <sys/apparmor.h>
+// #include <stdlib.h>
+import "C"
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"unsafe"
+)
+
+// IsEnabled returns true if apparmor is enabled for the host.
+func IsEnabled() bool {
+	if _, err := os.Stat("/sys/kernel/security/apparmor"); err == nil && os.Getenv("container") == "" {
+		if _, err = os.Stat("/sbin/apparmor_parser"); err == nil {
+			buf, err := ioutil.ReadFile("/sys/module/apparmor/parameters/enabled")
+			return err == nil && len(buf) > 1 && buf[0] == 'Y'
+		}
+	}
+	return false
+}
+
+// ApplyProfile will apply the profile with the specified name to the process after
+// the next exec.
+func ApplyProfile(name string) error {
+	if name == "" {
+		return nil
+	}
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+	if _, err := C.aa_change_onexec(cName); err != nil {
+		return fmt.Errorf("apparmor failed to apply profile: %s", err)
+	}
+	return nil
+}

--- a/vendor/github.com/opencontainers/runc/libcontainer/apparmor/apparmor_disabled.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/apparmor/apparmor_disabled.go
@@ -1,0 +1,20 @@
+// +build !apparmor !linux
+
+package apparmor
+
+import (
+	"errors"
+)
+
+var ErrApparmorNotEnabled = errors.New("apparmor: config provided but apparmor not supported")
+
+func IsEnabled() bool {
+	return false
+}
+
+func ApplyProfile(name string) error {
+	if name != "" {
+		return ErrApparmorNotEnabled
+	}
+	return nil
+}


### PR DESCRIPTION
Previous behavior:
* If selinux is not supported (not built / OS not support):
  * `EnableSelinux=true`: cri-containerd doesn't report any error, but won't set any selinux options. **(Not Expected)**
  * `EnableSelinux=false`: cri-containerd doesn't set selinux options.
* If apparmor is not supported (not built / OS not support):
  * `EnableAppArmor=true`: cri-containerd always applies default to container and we'll never be able to start a container.**(Not Expected)**
  * `EnableAppArmor=false`: cri-containerd won't apply apparmor profile.

With this PR, for either selinux or apparmor, if the feature is not supported, cri-containerd will:
* `EnableXXX=true`: cri-containerd will log an error at start up, and not set corresponding options. The log will be something like:
```
E0922 04:43:31.108763   17069 cri_containerd.go:74] Selinux is not supported
```
* `EnableXXX=false`: cri-containerd won't set corresponding options.

Another option is to let cri-containerd fail at start up directly if a non-supported feature is enabled, I'm not sure which is better.
@miaoyq @mikebrow 

Signed-off-by: Lantao Liu <lantaol@google.com>