### PR TITLE
Adds support for configuring the containerd runtime engine

### DIFF
--- a/pkg/server/container_create.go
+++ b/pkg/server/container_create.go
@@ -147,7 +147,7 @@ func (c *criContainerdService) CreateContainer(ctx context.Context, r *runtime.C
 
 	// Set snapshotter before any other options.
 	opts := []containerd.NewContainerOpts{
-		containerd.WithSnapshotter(c.config.ContainerdSnapshotter),
+		containerd.WithSnapshotter(c.config.ContainerdConfig.Snapshotter),
 		// Prepare container rootfs. This is always writeable even if
 		// the container wants a readonly rootfs since we want to give
 		// the runtime (runc) a chance to modify (e.g. to create mount
@@ -223,9 +223,11 @@ func (c *criContainerdService) CreateContainer(ctx context.Context, r *runtime.C
 	opts = append(opts,
 		containerd.WithSpec(spec, specOpts...),
 		containerd.WithRuntime(
-			defaultRuntime,
-			&runcopts.RuncOptions{SystemdCgroup: c.config.SystemdCgroup},
-		),
+			c.config.ContainerdConfig.Runtime,
+			&runcopts.RuncOptions{
+				Runtime:       c.config.ContainerdConfig.RuntimeEngine,
+				RuntimeRoot:   c.config.ContainerdConfig.RuntimeRoot,
+				SystemdCgroup: c.config.SystemdCgroup}), // TODO (mikebrow): add CriuPath when we add support for pause
 		containerd.WithContainerLabels(map[string]string{containerKindLabel: containerKindContainer}),
 		containerd.WithContainerExtension(containerMetadataExtension, &meta))
 	var cntr containerd.Container

--- a/pkg/server/helpers.go
+++ b/pkg/server/helpers.go
@@ -67,9 +67,6 @@ const (
 	defaultShmSize = int64(1024 * 1024 * 64)
 	// relativeRootfsPath is the rootfs path relative to bundle path.
 	relativeRootfsPath = "rootfs"
-	// defaultRuntime is the runtime to use in containerd. We may support
-	// other runtime in the future.
-	defaultRuntime = "io.containerd.runtime.v1.linux"
 	// sandboxesDir contains all sandbox root. A sandbox root is the running
 	// directory of the sandbox, all files created for the sandbox will be
 	// placed under this directory.

--- a/pkg/server/image_pull.go
+++ b/pkg/server/image_pull.go
@@ -102,7 +102,7 @@ func (c *criContainerdService) PullImage(ctx context.Context, r *runtime.PullIma
 		containerd.WithPullUnpack,
 		containerd.WithSchema1Conversion,
 		containerd.WithResolver(resolver),
-		containerd.WithPullSnapshotter(c.config.ContainerdSnapshotter),
+		containerd.WithPullSnapshotter(c.config.ContainerdConfig.Snapshotter),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to pull image %q: %v", ref, err)

--- a/pkg/server/service.go
+++ b/pkg/server/service.go
@@ -109,10 +109,10 @@ type criContainerdService struct {
 
 // NewCRIContainerdService returns a new instance of CRIContainerdService
 func NewCRIContainerdService(config options.Config) (CRIContainerdService, error) {
-	client, err := containerd.New(config.ContainerdEndpoint, containerd.WithDefaultNamespace(k8sContainerdNamespace))
+	client, err := containerd.New(config.ContainerdConfig.Endpoint, containerd.WithDefaultNamespace(k8sContainerdNamespace))
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize containerd client with endpoint %q: %v",
-			config.ContainerdEndpoint, err)
+			config.ContainerdConfig.Endpoint, err)
 	}
 	if config.CgroupPath != "" {
 		_, err := loadCgroup(config.CgroupPath)
@@ -138,7 +138,7 @@ func NewCRIContainerdService(config options.Config) (CRIContainerdService, error
 		client:              client,
 	}
 
-	imageFSPath := imageFSPath(config.ContainerdRootDir, config.ContainerdSnapshotter)
+	imageFSPath := imageFSPath(config.ContainerdConfig.RootDir, config.ContainerdConfig.Snapshotter)
 	c.imageFSUUID, err = c.getDeviceUUID(imageFSPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get imagefs uuid: %v", err)
@@ -182,7 +182,7 @@ func (c *criContainerdService) Run() error {
 	glog.V(2).Info("Start snapshots syncer")
 	snapshotsSyncer := newSnapshotsSyncer(
 		c.snapshotStore,
-		c.client.SnapshotService(c.config.ContainerdSnapshotter),
+		c.client.SnapshotService(c.config.ContainerdConfig.Snapshotter),
 		time.Duration(c.config.StatsCollectPeriod)*time.Second,
 	)
 	snapshotsSyncer.start()


### PR DESCRIPTION
Enables changing the defaults used by containerd for the location of runtime state (/var/lib/containerd by default), the name of the runc compatible runtime-engine (runc by default), and whether systemd cgroup support is enabled (false by default).

Note: these are specified in the containerd client api as options on each new container. 

Signed-off-by: Mike Brown <brownwm@us.ibm.com>