### PR TITLE
Add net.ipv4.ip_forward=1 and use ansible sysctl.

### DIFF
--- a/contrib/ansible/cri-containerd.yaml
+++ b/contrib/ansible/cri-containerd.yaml
@@ -15,16 +15,17 @@
     
     - name: "Start CRI-Containerd"
       systemd: name=cri-containerd daemon_reload=yes state=started enabled=yes
-    
-    - name: "Set bridge-nf-call-iptables"
-      lineinfile:
-        line: "net/bridge/bridge-nf-call-iptables = 1"
-        dest: /etc/sysctl.conf
-        insertafter: 'EOF'
-        regexp: '\/net\/bridge\/bridge-nf-call-iptables = 1'
-        state: present
-      ignore_errors: true
-    
+
+    - name: "Set bridge-nf-call-iptables" 
+      sysctl:
+        name: net.bridge.bridge-nf-call-iptables
+        value: 1
+
+    - name: "Set ip_forward" 
+      sysctl:
+        name: net.ipv4.ip_forward
+        value: 1
+
     - name: "Check kubelet args in kubelet config"
       shell: grep "^Environment=\"KUBELET_EXTRA_ARGS=" /etc/systemd/system/kubelet.service.d/10-kubeadm.conf 
       ignore_errors: true
@@ -32,9 +33,9 @@
 
     - name: "Add runtime args in kubelet conf"
       lineinfile:
-                dest: "/etc/systemd/system/kubelet.service.d/10-kubeadm.conf"
-                line: "Environment=\"KUBELET_EXTRA_ARGS= --container-runtime=remote --runtime-request-timeout=15m --image-service-endpoint=/var/run/cri-containerd.sock --container-runtime-endpoint=/var/run/cri-containerd.sock\""
-                insertafter: '\[Service\]'
+        dest: "/etc/systemd/system/kubelet.service.d/10-kubeadm.conf"
+        line: "Environment=\"KUBELET_EXTRA_ARGS= --container-runtime=remote --runtime-request-timeout=15m --image-service-endpoint=/var/run/cri-containerd.sock --container-runtime-endpoint=/var/run/cri-containerd.sock\""
+        insertafter: '\[Service\]'
       when: check_args.stdout == ""
     
     - name: "Start Kubelet"
@@ -43,6 +44,6 @@
     # TODO This needs to be removed once we have consistent concurrent pull results
     - name: "Pre-pull pause container image"
       shell: |
-             /usr/local/bin/ctr pull gcr.io/google_containers/pause:3.0
-             /usr/local/bin/crictl --runtime-endpoint /var/run/cri-containerd.sock \
-             pull gcr.io/google_containers/pause:3.0
+        /usr/local/bin/ctr pull gcr.io/google_containers/pause:3.0
+        /usr/local/bin/crictl --runtime-endpoint /var/run/cri-containerd.sock \
+        pull gcr.io/google_containers/pause:3.0


### PR DESCRIPTION
This PR:
1) Set `net.ipv4.ip_forward=1`, which is required by Kubernetes.
2) Use ansible sysctl support instead. Current code has an extra `\/` in front of the regexp, which will never match, thus ansible will put a sysctl entry each time it runs.
3) Format the indent a little bit.

Signed-off-by: Lantao Liu <lantaol@google.com>