### PR TITLE
Improve ansible playbook.

### DIFF
--- a/contrib/ansible/cri-containerd.yaml
+++ b/contrib/ansible/cri-containerd.yaml
@@ -16,6 +16,11 @@
     - name: "Start CRI-Containerd"
       systemd: name=cri-containerd daemon_reload=yes state=started enabled=yes
 
+    - name: "Load br_netfilter kernel module"
+      modprobe:
+        name: br_netfilter
+        state: present
+
     - name: "Set bridge-nf-call-iptables" 
       sysctl:
         name: net.bridge.bridge-nf-call-iptables
@@ -27,14 +32,13 @@
         value: 1
 
     - name: "Check kubelet args in kubelet config"
-      shell: grep "^Environment=\"KUBELET_EXTRA_ARGS=" /etc/systemd/system/kubelet.service.d/10-kubeadm.conf 
-      ignore_errors: true
+      shell: grep "^Environment=\"KUBELET_EXTRA_ARGS=" /etc/systemd/system/kubelet.service.d/10-kubeadm.conf || true
       register: check_args
 
     - name: "Add runtime args in kubelet conf"
       lineinfile:
         dest: "/etc/systemd/system/kubelet.service.d/10-kubeadm.conf"
-        line: "Environment=\"KUBELET_EXTRA_ARGS= --container-runtime=remote --runtime-request-timeout=15m --image-service-endpoint=/var/run/cri-containerd.sock --container-runtime-endpoint=/var/run/cri-containerd.sock\""
+        line: "Environment=\"KUBELET_EXTRA_ARGS= --container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=/var/run/cri-containerd.sock\""
         insertafter: '\[Service\]'
       when: check_args.stdout == ""
     

--- a/contrib/ansible/tasks/bootstrap_centos.yaml
+++ b/contrib/ansible/tasks/bootstrap_centos.yaml
@@ -6,8 +6,8 @@
   with_items:
     - unzip
     - tar
-    - btrfs-progs-devel
-    - libseccomp-devel
+    - btrfs-progs
+    - libseccomp
     - util-linux 
     - socat
     - libselinux-python

--- a/contrib/ansible/tasks/bootstrap_ubuntu.yaml
+++ b/contrib/ansible/tasks/bootstrap_ubuntu.yaml
@@ -8,8 +8,7 @@
       - tar
       - apt-transport-https
       - btrfs-tools
-      - libapparmor-dev
-      - libseccomp-dev # Revisit the need and alternatives for all -dev packages
+      - libapparmor1
       - libseccomp2
       - socat
       - util-linux

--- a/contrib/ansible/vars/vars.yaml
+++ b/contrib/ansible/vars/vars.yaml
@@ -1,6 +1,6 @@
 ---
 # TODO update official versions once they are available
-cri_containerd_release_version: 0.1.0-247-g10df5f7
+cri_containerd_release_version: 0.1.0-258-g529971a
 cri_release_directory: /opt/cri-containerd/
 local_bin_dir: /usr/local/bin/
 local_sbin_dir: /usr/local/sbin/


### PR DESCRIPTION
This PR:
1) Add `modprobe br_netfilter`, which is required by kubelet. Without which `net.bridge.bridge-nf-call-iptables` won't work, either.
2) Stop using dev library, which is not needed for running cri-containerd.
3) Add systemd dropin for cri-containerd, previous solution always report an error during installation, which is confusing to user.
4) Update cri-containerd to newest version.

Signed-off-by: Lantao Liu <lantaol@google.com>