### PR TITLE
Do not include CNI binaries/configs in release tarball.

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -29,7 +29,7 @@ TARBALL=${TARBALL:-"cri-containerd.tar.gz"}
 destdir=${BUILD_DIR}/release-stage
 
 # Install dependencies into release stage.
-NOSUDO=true DESTDIR=${destdir} ./hack/install-deps.sh
+NOSUDO=true INSTALL_CNI=false DESTDIR=${destdir} ./hack/install-deps.sh
 
 # Install cri-containerd into release stage.
 make install -e DESTDIR=${destdir}


### PR DESCRIPTION
Do not include CNI binaries/configs in release tarball. In real use, user should launch their own CNI daemonset to deploy cni binaries and configs, we should not include one in release tarball.

@abhinandanpb @mikebrow 
Signed-off-by: Lantao Liu <lantaol@google.com>