### PR TITLE
Add systemd cgroup support.

### DIFF
--- a/cmd/cri-containerd/options/options.go
+++ b/cmd/cri-containerd/options/options.go
@@ -70,6 +70,8 @@ type Config struct {
 	SandboxImage string `toml:"sandbox_image"`
 	// StatsCollectPeriod is the period (in seconds) of snapshots stats collection.
 	StatsCollectPeriod int `toml:"stats_collect_period"`
+	// SystemdCgroup enables systemd cgroup support.
+	SystemdCgroup bool `toml:"systemd_cgroup"`
 }
 
 // CRIContainerdOptions contains cri-containerd command line and toml options.
@@ -122,6 +124,8 @@ func (c *CRIContainerdOptions) AddFlags(fs *pflag.FlagSet) {
 		"gcr.io/google_containers/pause:3.0", "The image used by sandbox container.")
 	fs.IntVar(&c.StatsCollectPeriod, "stats-collect-period",
 		10, "The period (in seconds) of snapshots stats collection.")
+	fs.BoolVar(&c.SystemdCgroup, "systemd-cgroup",
+		false, "Enables systemd cgroup support.")
 	fs.BoolVar(&c.PrintDefaultConfig, "default-config",
 		false, "Print default toml config of cri-containerd and quit.")
 }

--- a/pkg/server/container_create_test.go
+++ b/pkg/server/container_create_test.go
@@ -149,7 +149,7 @@ func getCreateContainerTestData() (*runtime.ContainerConfig, *runtime.PodSandbox
 		assert.Equal(t, spec.Process.NoNewPrivileges, true)
 
 		t.Logf("Check cgroup path")
-		assert.Equal(t, getCgroupsPath("/test/cgroup/parent", id), spec.Linux.CgroupsPath)
+		assert.Equal(t, getCgroupsPath("/test/cgroup/parent", id, false), spec.Linux.CgroupsPath)
 
 		t.Logf("Check namespaces")
 		assert.Contains(t, spec.Linux.Namespaces, runtimespec.LinuxNamespace{

--- a/pkg/server/helpers.go
+++ b/pkg/server/helpers.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -134,8 +135,13 @@ func makeContainerName(c *runtime.ContainerMetadata, s *runtime.PodSandboxMetada
 }
 
 // getCgroupsPath generates container cgroups path.
-func getCgroupsPath(cgroupsParent string, id string) string {
-	// TODO(random-liu): [P0] Handle systemd.
+func getCgroupsPath(cgroupsParent, id string, systemdCgroup bool) string {
+	if systemdCgroup {
+		// Convert a.slice/b.slice/c.slice to c.slice.
+		p := path.Base(cgroupsParent)
+		// runc systemd cgroup path format is "slice:prefix:name".
+		return strings.Join([]string{p, "cri-containerd", id}, ":")
+	}
 	return filepath.Join(cgroupsParent, id)
 }
 

--- a/pkg/server/helpers_test.go
+++ b/pkg/server/helpers_test.go
@@ -161,3 +161,27 @@ func TestGetRepoDigestAndTag(t *testing.T) {
 		assert.Equal(t, test.expectedRepoTag, repoTag)
 	}
 }
+
+func TestGetCgroupsPath(t *testing.T) {
+	testID := "test-id"
+	for desc, test := range map[string]struct {
+		cgroupsParent string
+		systemdCgroup bool
+		expected      string
+	}{
+		"should support regular cgroup path": {
+			cgroupsParent: "/a/b",
+			systemdCgroup: false,
+			expected:      "/a/b/test-id",
+		},
+		"should support systemd cgroup path": {
+			cgroupsParent: "/a.slice/b.slice",
+			systemdCgroup: true,
+			expected:      "b.slice:cri-containerd:test-id",
+		},
+	} {
+		t.Logf("TestCase %q", desc)
+		got := getCgroupsPath(test.cgroupsParent, testID, test.systemdCgroup)
+		assert.Equal(t, test.expected, got)
+	}
+}

--- a/pkg/server/sandbox_run_test.go
+++ b/pkg/server/sandbox_run_test.go
@@ -56,7 +56,7 @@ func getRunPodSandboxTestData() (*runtime.PodSandboxConfig, *imagespec.ImageConf
 	}
 	specCheck := func(t *testing.T, id string, spec *runtimespec.Spec) {
 		assert.Equal(t, "test-hostname", spec.Hostname)
-		assert.Equal(t, getCgroupsPath("/test/cgroup/parent", id), spec.Linux.CgroupsPath)
+		assert.Equal(t, getCgroupsPath("/test/cgroup/parent", id, false), spec.Linux.CgroupsPath)
 		assert.Equal(t, relativeRootfsPath, spec.Root.Path)
 		assert.Equal(t, true, spec.Root.Readonly)
 		assert.Contains(t, spec.Process.Env, "a=b", "c=d")


### PR DESCRIPTION
Add systemd cgroup support.
This is part of https://github.com/kubernetes-incubator/cri-containerd/pull/275 and one of missing features in https://github.com/kubernetes-incubator/cri-containerd/issues/62.

Signed-off-by: Lantao Liu <lantaol@google.com>