### PR TITLE
Better format several errors

### DIFF
--- a/cmd/cri-containerd/cri_containerd.go
+++ b/cmd/cri-containerd/cri_containerd.go
@@ -40,7 +40,7 @@ func main() {
 		glog.Exitf("Failed to init CRI containerd flags: %v", err)
 	}
 
-	glog.V(2).Infof("Run cri-containerd %+v", o)
+	glog.V(0).Infof("Run cri-containerd %+v", o)
 	if o.PrintVersion {
 		version.PrintVersion()
 		os.Exit(0)
@@ -56,7 +56,7 @@ func main() {
 	glog.V(2).Infof("Run cri-containerd grpc server on socket %q", o.SocketPath)
 	s, err := server.NewCRIContainerdService(o.Config)
 	if err != nil {
-		glog.Exitf("Failed to create CRI containerd service %+v: %v", o, err)
+		glog.Exitf("Failed to create CRI containerd service: %v", err)
 	}
 	// Use interrupt handler to make sure the server to be stopped properly.
 	// Pass in non-empty final function to avoid os.Exit(1). We expect `Run`

--- a/pkg/os/os.go
+++ b/pkg/os/os.go
@@ -155,5 +155,5 @@ func (RealOS) DeviceUUID(device string) (string, error) {
 			return file.Name(), nil
 		}
 	}
-	return "", fmt.Errorf("device not found")
+	return "", fmt.Errorf("device %q not found", device)
 }

--- a/pkg/server/service.go
+++ b/pkg/server/service.go
@@ -141,7 +141,7 @@ func NewCRIContainerdService(config options.Config) (CRIContainerdService, error
 	imageFSPath := imageFSPath(config.ContainerdConfig.RootDir, config.ContainerdConfig.Snapshotter)
 	c.imageFSUUID, err = c.getDeviceUUID(imageFSPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get imagefs uuid: %v", err)
+		return nil, fmt.Errorf("failed to get imagefs uuid of %q: %v", imageFSPath, err)
 	}
 
 	c.netPlugin, err = ocicni.InitCNI(config.NetworkPluginConfDir, config.NetworkPluginBinDir)


### PR DESCRIPTION
Information seems not sufficient from https://github.com/kubernetes-incubator/cri-containerd/issues/298.
Format several error mesage. 
Signed-off-by: Lantao Liu <lantaol@google.com>