### PR TITLE
Update ansible playbook release version.

### DIFF
--- a/contrib/ansible/tasks/binaries.yaml
+++ b/contrib/ansible/tasks/binaries.yaml
@@ -1,7 +1,7 @@
 ---
 - name: "Get Containerd and CRI-Containerd"
   unarchive:
-    src: "https://storage.googleapis.com/cri-containerd-staging/cri-containerd-{{ cri_containerd_release_version }}.tar.gz"
+    src: "https://storage.googleapis.com/cri-containerd-release/cri-containerd-{{ cri_containerd_release_version }}.tar.gz"
     dest: "/"
     remote_src: yes
 

--- a/contrib/ansible/vars/vars.yaml
+++ b/contrib/ansible/vars/vars.yaml
@@ -1,6 +1,6 @@
 ---
 # TODO update official versions once they are available
-cri_containerd_release_version: 0.1.0-271-g86ee919
+cri_containerd_release_version: 1.0.0-alpha.0
 cri_release_directory: /opt/cri-containerd/
 local_bin_dir: /usr/local/bin/
 local_sbin_dir: /usr/local/sbin/


### PR DESCRIPTION
Update ansible playbook to use v1.0.0-alpha.0 release.

Signed-off-by: Lantao Liu <lantaol@google.com>