### PR TITLE
Add node e2e test timeout.

### DIFF
--- a/hack/test-e2e-node.sh
+++ b/hack/test-e2e-node.sh
@@ -30,6 +30,8 @@ export SKIP=${SKIP:-${DEFAULT_SKIP}}
 REPORT_DIR=${REPORT_DIR:-"/tmp/test-e2e-node"}
 # UPLOAD_LOG indicates whether to upload test log to gcs.
 UPLOAD_LOG=${UPLOAD_LOG:-false}
+# TIMEOUT is the timeout of the test.
+TIMEOUT=${TIMEOUT:-"40m"}
 
 # Check GOPATH
 if [[ -z "${GOPATH}" ]]; then
@@ -71,7 +73,7 @@ git checkout ${KUBERNETES_VERSION}
 mkdir -p ${REPORT_DIR}
 test_setup ${REPORT_DIR}
 
-make test-e2e-node \
+timeout "${TIMEOUT}" make test-e2e-node \
 	RUNTIME=remote \
 	CONTAINER_RUNTIME_ENDPOINT=unix://${CRICONTAINERD_SOCK} \
 	ARTIFACTS=${REPORT_DIR} \


### PR DESCRIPTION
Add timeout for node e2e test.

The build is red now, it seems that cri-containerd or containerd gets unresponsive during test running. However,
1) I could not reproduce it in my local machine;
2) because of travis 50m test timeout, it doesn't even get a chance to upload test log, so that there is no way to debug it.

This PR added 40m timeout to node e2e test. Usually it only takes 30-31 minutes. If it timeout, test will abort, and we still get the chance to collect test logs.

Signed-off-by: Lantao Liu <lantaol@google.com>