### PR TITLE
Change `Version` to return cri-containerd version instead.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,14 +18,14 @@ PROJECT := github.com/kubernetes-incubator/cri-containerd
 BINDIR := ${DESTDIR}/usr/local/bin
 BUILD_DIR := _output
 # VERSION is derived from the current tag for HEAD plus amends. Version is used
-# to set/overide the criContainerdVersion variable in the verison package for
+# to set/overide the CRIContainerdVersion variable in the verison package for
 # cri-containerd.
 VERSION := $(shell git describe --tags --dirty)
 # strip the first char of the tag if it's a `v`
 VERSION := $(VERSION:v%=%)
 TARBALL := cri-containerd-$(VERSION).tar.gz
 BUILD_TAGS := seccomp apparmor
-GO_LDFLAGS := -X $(PROJECT)/pkg/version.criContainerdVersion=$(VERSION)
+GO_LDFLAGS := -X $(PROJECT)/pkg/version.CRIContainerdVersion=$(VERSION)
 SOURCES := $(shell find cmd/ pkg/ vendor/ -name '*.go')
 INTEGRATION_SOURCES := $(shell find integration/ -name '*.go')
 

--- a/pkg/server/version.go
+++ b/pkg/server/version.go
@@ -17,14 +17,19 @@ limitations under the License.
 package server
 
 import (
-	"fmt"
-
 	"golang.org/x/net/context"
 	"k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
+
+	"github.com/kubernetes-incubator/cri-containerd/pkg/version"
 )
 
 const (
-	containerName        = "containerd"
+	// For now, containerd and runc are bundled with cri-containerd, cri-containerd
+	// version is more important to us.
+	// TODO(random-liu): Figure out how to package cri-containerd and containerd,
+	// and how to version it. We still prefer calling the container runtime "containerd",
+	// but we care both the cri-containerd version and containerd version.
+	containerName        = "cri-containerd"
 	containerdAPIVersion = "0.0.0"
 	// kubeAPIVersion is the api version of kubernetes.
 	kubeAPIVersion = "0.1.0"
@@ -32,14 +37,10 @@ const (
 
 // Version returns the runtime name, runtime version and runtime API version.
 func (c *criContainerdService) Version(ctx context.Context, r *runtime.VersionRequest) (*runtime.VersionResponse, error) {
-	resp, err := c.client.Version(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get containerd version: %v", err)
-	}
 	return &runtime.VersionResponse{
 		Version:        kubeAPIVersion,
 		RuntimeName:    containerName,
-		RuntimeVersion: resp.Version,
+		RuntimeVersion: version.CRIContainerdVersion,
 		// Containerd doesn't have an api version now.
 		RuntimeApiVersion: containerdAPIVersion,
 	}, nil

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -22,7 +22,8 @@ import (
 	"github.com/blang/semver"
 )
 
-var criContainerdVersion = "UNKNOWN"
+// CRIContainerdVersion is the version of the cri-containerd.
+var CRIContainerdVersion = "UNKNOWN"
 
 func validateSemver(sv string) error {
 	_, err := semver.Parse(sv)
@@ -34,9 +35,9 @@ func validateSemver(sv string) error {
 
 // PrintVersion outputs the release version of cri-containerd
 func PrintVersion() {
-	err := validateSemver(criContainerdVersion)
+	err := validateSemver(CRIContainerdVersion)
 	if err != nil {
 		fmt.Println(err)
 	}
-	fmt.Println(criContainerdVersion)
+	fmt.Println(CRIContainerdVersion)
 }

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -28,6 +28,6 @@ func TestValidateSemver(t *testing.T) {
 	assert.NotNil(err)
 	err = validateSemver("0.0.0-1-gdf6a1cc-dirty")
 	assert.Nil(err)
-	err = validateSemver(criContainerdVersion)
+	err = validateSemver(CRIContainerdVersion)
 	assert.Nil(err)
 }


### PR DESCRIPTION
Changed `Version` to use cri-containerd version.
We still want to call the runtime `containerd` in the future not to confuse people, but we do need both cri-containerd and containerd version if we don't bundle them well.

This is a problem we need to discuss and fix, but for now just expose cri-containerd version for ease of our development, because we could always infer containerd version from cri-containerd version in our test environment.

Signed-off-by: Lantao Liu <lantaol@google.com>