### PR TITLE
Use device number to find uuid

### DIFF
--- a/pkg/os/os.go
+++ b/pkg/os/os.go
@@ -45,7 +45,7 @@ type OS interface {
 	Unmount(target string, flags int) error
 	GetMounts() ([]*mount.Info, error)
 	LookupMount(path string) (containerdmount.Info, error)
-	DeviceUUID(device string) (string, error)
+	DeviceUUID(device uint64) (string, error)
 }
 
 // RealOS is used to dispatch the real system level operations.
@@ -144,14 +144,9 @@ func blkrdev(device string) (uint64, error) {
 	return stat.Rdev, nil
 }
 
-// DeviceUUID gets device uuid of a device. The passed in device should be
-// an absolute path of the device.
-func (RealOS) DeviceUUID(device string) (string, error) {
-	rdev, err := blkrdev(device)
-	if err != nil {
-		return "", err
-	}
-
+// DeviceUUID gets device uuid of a device. The passed in rdev should be
+// linux device number.
+func (RealOS) DeviceUUID(rdev uint64) (string, error) {
 	const uuidDir = "/dev/disk/by-uuid"
 	files, err := ioutil.ReadDir(uuidDir)
 	if err != nil {
@@ -169,5 +164,5 @@ func (RealOS) DeviceUUID(device string) (string, error) {
 			return file.Name(), nil
 		}
 	}
-	return "", fmt.Errorf("device %q not found", device)
+	return "", fmt.Errorf("device %d not found", rdev)
 }

--- a/pkg/os/testing/fake_os.go
+++ b/pkg/os/testing/fake_os.go
@@ -52,7 +52,7 @@ type FakeOS struct {
 	UnmountFn             func(target string, flags int) error
 	GetMountsFn           func() ([]*mount.Info, error)
 	LookupMountFn         func(path string) (containerdmount.Info, error)
-	DeviceUUIDFn          func(device string) (string, error)
+	DeviceUUIDFn          func(device uint64) (string, error)
 	calls                 []CalledDetail
 	errors                map[string]error
 }
@@ -258,7 +258,7 @@ func (f *FakeOS) LookupMount(path string) (containerdmount.Info, error) {
 }
 
 // DeviceUUID is a fake call that invodes DeviceUUIDFn or just return nil.
-func (f *FakeOS) DeviceUUID(device string) (string, error) {
+func (f *FakeOS) DeviceUUID(device uint64) (string, error) {
 	f.appendCalls("DeviceUUID", device)
 	if err := f.getError("DeviceUUID"); err != nil {
 		return "", err


### PR DESCRIPTION
Use linux device number from `mount.Lookup` to look for uuid.

This may be able to fix https://github.com/kubernetes-incubator/cri-containerd/issues/325.

And I also see the Ubuntu used by GKE, rootfs is mounted from `/dev/root`, which doesn't have real corresponding device file.

With this fix, we get device number from mount directly, and find uuid with the device number. This doesn't assume that the mount source has to be a existing file.

Signed-off-by: Lantao Liu <lantaol@google.com>