### PR TITLE
Add staging tar for node e2e.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,4 +81,6 @@ jobs:
       script:
         - test "${TRAVIS_PULL_REQUEST}" != "false" && exit 0 || true
         - make push
+        # Build a tarball including CNI for node e2e.
+        - PUSH_VERSION=true make push TARBALL_PREFIX=cri-containerd-node-e2e INCLUDE_CNI=true
       go: 1.8.x

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,8 @@ BUILD_DIR := _output
 VERSION := $(shell git describe --tags --dirty)
 # strip the first char of the tag if it's a `v`
 VERSION := $(VERSION:v%=%)
-TARBALL := cri-containerd-$(VERSION).tar.gz
+TARBALL_PREFIX := cri-containerd
+TARBALL := $(TARBALL_PREFIX)-$(VERSION).tar.gz
 BUILD_TAGS := seccomp apparmor
 GO_LDFLAGS := -X $(PROJECT)/pkg/version.criContainerdVersion=$(VERSION)
 SOURCES := $(shell find cmd/ pkg/ vendor/ -name '*.go')
@@ -114,7 +115,7 @@ $(BUILD_DIR)/$(TARBALL): $(BUILD_DIR)/cri-containerd hack/versions
 release: $(BUILD_DIR)/$(TARBALL)
 
 push: $(BUILD_DIR)/$(TARBALL)
-	@BUILD_DIR=$(BUILD_DIR) TARBALL=$(TARBALL) ./hack/push.sh
+	@BUILD_DIR=$(BUILD_DIR) TARBALL=$(TARBALL) VERSION=$(VERSION) ./hack/push.sh
 
 .PHONY: install.deps
 

--- a/hack/push.sh
+++ b/hack/push.sh
@@ -23,6 +23,9 @@ source $(dirname "${BASH_SOURCE[0]}")/test-utils.sh
 DEPLOY_BUCKET=${DEPLOY_BUCKET:-"cri-containerd-staging"}
 BUILD_DIR=${BUILD_DIR:-"_output"}
 TARBALL=${TARBALL:-"cri-containerd.tar.gz"}
+LATEST=${LATEST:-"latest"}
+# PUSH_VERSION indicates whether to push version.
+PUSH_VERSION=${PUSH_VERSION:-false}
 
 release_tar=${ROOT}/${BUILD_DIR}/${TARBALL}
 if [ ! -e ${release_tar} ]; then
@@ -38,3 +41,13 @@ fi
 gsutil cp ${release_tar} "gs://${DEPLOY_BUCKET}/"
 echo "Release tarball is uploaded to:
   https://storage.googleapis.com/${DEPLOY_BUCKET}/${TARBALL}"
+
+if ${PUSH_VERSION}; then
+  if [[ -z "${VERSION}" ]]; then
+    echo "VERSION is not set"
+    exit 1
+  fi
+  echo ${VERSION} | gsutil cp - "gs://${DEPLOY_BUCKET}/${LATEST}"
+  echo "Latest version is uploaded to:
+  https://storage.googleapis.com/${DEPLOY_BUCKET}/${LATEST}"
+fi

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -25,11 +25,14 @@ cd ${ROOT}
 # TARBALL is the name of the release tar.
 BUILD_DIR=${BUILD_DIR:-"_output"}
 TARBALL=${TARBALL:-"cri-containerd.tar.gz"}
+# INCLUDE_CNI indicates whether to install CNI. By default don't
+# include CNI in release tarball.
+INCLUDE_CNI=${INCLUDE_CNI:-false}
 
 destdir=${BUILD_DIR}/release-stage
 
 # Install dependencies into release stage.
-NOSUDO=true INSTALL_CNI=false DESTDIR=${destdir} ./hack/install-deps.sh
+NOSUDO=true INSTALL_CNI=${INCLUDE_CNI} DESTDIR=${destdir} ./hack/install-deps.sh
 
 # Install cri-containerd into release stage.
 make install -e DESTDIR=${destdir}


### PR DESCRIPTION
This PR:
1) Add separate tar for node e2e test which contains CNI in the tar.
2) Push a file named `latest` in `cri-containerd-staging`. Other tool could read `latest` to know the latest version. /cc @abhi 

Fixes https://github.com/kubernetes-incubator/cri-containerd/issues/304.

Signed-off-by: Lantao Liu <lantaol@google.com>