### PR TITLE
Disable maligned check.

### DIFF
--- a/hack/verify-lint.sh
+++ b/hack/verify-lint.sh
@@ -25,6 +25,7 @@ for d in $(find . -type d -a \( -iwholename './pkg*' -o -iwholename './cmd*' \))
 		 --exclude='duplicate of.*_test.go.*\(dupl\)$' \
 		 --exclude='.*/mock_.*\.go:.*\(golint\)$' \
 		 --exclude='declaration of "err" shadows declaration.*\(vetshadow\)$' \
+		 --exclude='struct of size .* could be .* \(maligned\)$' \
 		 --disable=aligncheck \
 		 --disable=gotype \
 		 --disable=gas \


### PR DESCRIPTION
It seems that there is some update on the gometalinter side.
The build is failing because of something like:
```
pkg/store/container/status.go:43:13:warning: struct of size 80 could be 72 (maligned)
```

Personally, I don't think we care about this that much. Code readability is more important for us. For example, we may want to place struct fields in logic order instead of moving them around to make the struct align better.

@abhi @mikebrow WDYT?

Signed-off-by: Lantao Liu <lantaol@google.com>