### PR TITLE
Remove the oom score in systemd unit. cri-containerd sets it by itself.

### DIFF
--- a/contrib/systemd-units/cri-containerd.service
+++ b/contrib/systemd-units/cri-containerd.service
@@ -7,7 +7,6 @@ After=containerd.service
 Restart=always
 RestartSec=5
 ExecStart=/usr/local/bin/cri-containerd --logtostderr
-OOMScoreAdjust=-999
 
 [Install]
 WantedBy=multi-user.target

--- a/test/e2e_node/init.yaml
+++ b/test/e2e_node/init.yaml
@@ -68,7 +68,6 @@ write_files:
       [Service]
       Restart=always
       RestartSec=5
-      OOMScoreAdjust=-999
       ExecStart=/home/cri-containerd/usr/local/bin/cri-containerd \
         --alsologtostderr --v=4 \
         --network-bin-dir=/home/cri-containerd/opt/cni/bin \


### PR DESCRIPTION
Remove OOMScore from systemd units. The default -999 oom score is set in https://github.com/kubernetes-incubator/cri-containerd/pull/347.

Signed-off-by: Lantao Liu <lantaol@google.com>