### PR TITLE
typo: subtract not substract.

### DIFF
--- a/pkg/server/container_create_test.go
+++ b/pkg/server/container_create_test.go
@@ -217,7 +217,7 @@ func TestContainerCapabilities(t *testing.T) {
 				AddCapabilities:  []string{"ALL"},
 				DropCapabilities: []string{"CHOWN"},
 			},
-			includes: util.SubstractStringSlice(getOCICapabilitiesList(), "CAP_CHOWN"),
+			includes: util.SubtractStringSlice(getOCICapabilitiesList(), "CAP_CHOWN"),
 			excludes: []string{"CAP_CHOWN"},
 		},
 		"should be able to add capabilities with drop all": {
@@ -226,7 +226,7 @@ func TestContainerCapabilities(t *testing.T) {
 				DropCapabilities: []string{"ALL"},
 			},
 			includes: []string{"CAP_SYS_ADMIN"},
-			excludes: util.SubstractStringSlice(getOCICapabilitiesList(), "CAP_SYS_ADMIN"),
+			excludes: util.SubtractStringSlice(getOCICapabilitiesList(), "CAP_SYS_ADMIN"),
 		},
 	} {
 		t.Logf("TestCase %q", desc)

--- a/pkg/util/strings.go
+++ b/pkg/util/strings.go
@@ -29,9 +29,9 @@ func InStringSlice(ss []string, str string) bool {
 	return false
 }
 
-// SubstractStringSlice substracts string from string slice.
+// SubtractStringSlice subtracts string from string slice.
 // Comparison is case insensitive.
-func SubstractStringSlice(ss []string, str string) []string {
+func SubtractStringSlice(ss []string, str string) []string {
 	var res []string
 	for _, s := range ss {
 		if strings.ToLower(s) == strings.ToLower(str) {

--- a/pkg/util/strings_test.go
+++ b/pkg/util/strings_test.go
@@ -34,15 +34,15 @@ func TestInStringSlice(t *testing.T) {
 	assert.False(t, InStringSlice(nil, "HIJ"))
 }
 
-func TestSubstractStringSlice(t *testing.T) {
+func TestSubtractStringSlice(t *testing.T) {
 	ss := []string{"ABC", "def", "ghi"}
 
-	assert.Equal(t, []string{"def", "ghi"}, SubstractStringSlice(ss, "abc"))
-	assert.Equal(t, []string{"def", "ghi"}, SubstractStringSlice(ss, "ABC"))
-	assert.Equal(t, []string{"ABC", "ghi"}, SubstractStringSlice(ss, "def"))
-	assert.Equal(t, []string{"ABC", "ghi"}, SubstractStringSlice(ss, "DEF"))
-	assert.Equal(t, []string{"ABC", "def", "ghi"}, SubstractStringSlice(ss, "hij"))
-	assert.Equal(t, []string{"ABC", "def", "ghi"}, SubstractStringSlice(ss, "HIJ"))
-	assert.Empty(t, SubstractStringSlice(nil, "hij"))
-	assert.Empty(t, SubstractStringSlice([]string{}, "hij"))
+	assert.Equal(t, []string{"def", "ghi"}, SubtractStringSlice(ss, "abc"))
+	assert.Equal(t, []string{"def", "ghi"}, SubtractStringSlice(ss, "ABC"))
+	assert.Equal(t, []string{"ABC", "ghi"}, SubtractStringSlice(ss, "def"))
+	assert.Equal(t, []string{"ABC", "ghi"}, SubtractStringSlice(ss, "DEF"))
+	assert.Equal(t, []string{"ABC", "def", "ghi"}, SubtractStringSlice(ss, "hij"))
+	assert.Equal(t, []string{"ABC", "def", "ghi"}, SubtractStringSlice(ss, "HIJ"))
+	assert.Empty(t, SubtractStringSlice(nil, "hij"))
+	assert.Empty(t, SubtractStringSlice([]string{}, "hij"))
 }


### PR DESCRIPTION
Signed-off-by: Ian Campbell <ijc@docker.com>

I happened to spot this in https://goreportcard.com/report/github.com/kubernetes-incubator/cri-containerd, should take our misspell score from 98% to 100%.