### PR TITLE
Add e2e test

### DIFF
--- a/test/build.sh
+++ b/test/build.sh
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO(random-liu): Remove this after test-infra side is updated.
 # This script is used to build and upload cri-containerd in gcr.io/k8s-testimages/kubekins-e2e.
 
 set -o xtrace
@@ -46,7 +45,7 @@ apt-get install -y libseccomp-dev/jessie-backports
 apt-get install -y libapparmor-dev
 
 # PULL_REFS is from prow.
-if [ ! -z "${PULL_REFS:-""}" ]; then 
+if [ ! -z "${PULL_REFS:-""}" ]; then
   DEPLOY_DIR=$(echo "${PULL_REFS}" | sha1sum | awk '{print $1}')
 fi
 

--- a/test/e2e/master.yaml
+++ b/test/e2e/master.yaml
@@ -1,0 +1,202 @@
+#cloud-config
+
+write_files:
+# Setup cri-containerd.
+  - path: /etc/systemd/system/cri-containerd-installation.service
+    permissions: 0644
+    owner: root
+    content: |
+      # installed by cloud-init
+      [Unit]
+      Description=Download and install cri-containerd binaries and configurations.
+      After=network-online.target
+
+      [Service]
+      Type=oneshot
+      RemainAfterExit=yes
+      ExecStartPre=/bin/mkdir -p /home/cri-containerd
+      ExecStartPre=/bin/mount --bind /home/cri-containerd /home/cri-containerd
+      ExecStartPre=/bin/mount -o remount,exec /home/cri-containerd
+      ExecStartPre=/usr/bin/curl --fail --retry 5 --retry-delay 3 --silent --show-error -H "X-Google-Metadata-Request: True" -o /home/cri-containerd/configure.sh http://metadata.google.internal/computeMetadata/v1/instance/attributes/cri-containerd-configure-sh
+      ExecStartPre=/bin/chmod 544 /home/cri-containerd/configure.sh
+      ExecStart=/home/cri-containerd/configure.sh
+
+      [Install]
+      WantedBy=cri-containerd.target
+
+  - path: /etc/containerd/config.toml
+    permissions: 0644
+    owner: root
+    content: |
+      # installed by cloud-init
+      oom_score = -999
+
+      [plugins.linux]
+        shim = "/home/cri-containerd/usr/local/bin/containerd-shim"
+        runtime = "/home/cri-containerd/usr/local/sbin/runc"
+
+  # TODO(random-liu): Add health monitor for containerd/cri-containerd.
+  - path: /etc/systemd/system/containerd.service
+    permissions: 0644
+    owner: root
+    content: |
+      # installed by cloud-init
+      [Unit]
+      Description=containerd container runtime
+      Documentation=https://containerd.io
+      After=cri-containerd-installation.service
+
+      [Service]
+      Restart=always
+      RestartSec=5
+      Delegate=yes
+      KillMode=process
+      ExecStartPre=/sbin/modprobe overlay
+      ExecStart=/home/cri-containerd/usr/local/bin/containerd --log-level debug
+
+      [Install]
+      WantedBy=cri-containerd.target
+
+  - path: /etc/systemd/system/cri-containerd.service
+    permissions: 0644
+    owner: root
+    content: |
+      # installed by cloud-init
+      [Unit]
+      Description=Kubernetes containerd CRI shim
+      Requires=network-online.target
+      After=cri-containerd-installation.service
+
+      [Service]
+      Restart=always
+      RestartSec=5
+      # cri-containerd on master uses the cni binary and config in the
+      # release tarball.
+      ExecStart=/home/cri-containerd/usr/local/bin/cri-containerd \
+        --logtostderr --v=4 \
+        --network-bin-dir=/home/cri-containerd/opt/cni/bin \
+        --network-conf-dir=/home/cri-containerd/etc/cni/net.d
+
+      [Install]
+      WantedBy=cri-containerd.target
+
+  # TODO(random-liu): Guarantee order.
+  - path: /etc/systemd/system/cri-containerd.target
+    permissions: 0644
+    owner: root
+    content: |
+      [Unit]
+      Description=CRI Containerd
+
+      [Install]
+      WantedBy=kubernetes.target
+
+# Setup kubernetes.
+  - path: /etc/systemd/system/kube-master-installation.service
+    permissions: 0644
+    owner: root
+    content: |
+      [Unit]
+      Description=Download and install k8s binaries and configurations
+      After=network-online.target
+
+      [Service]
+      Type=oneshot
+      RemainAfterExit=yes
+      ExecStartPre=/bin/mkdir -p /home/kubernetes/bin
+      ExecStartPre=/bin/mount --bind /home/kubernetes/bin /home/kubernetes/bin
+      ExecStartPre=/bin/mount -o remount,exec /home/kubernetes/bin
+      ExecStartPre=/usr/bin/curl --fail --retry 5 --retry-delay 3 --silent --show-error	-H "X-Google-Metadata-Request: True" -o /home/kubernetes/bin/configure.sh http://metadata.google.internal/computeMetadata/v1/instance/attributes/configure-sh
+      ExecStartPre=/bin/chmod 544 /home/kubernetes/bin/configure.sh
+      ExecStart=/home/kubernetes/bin/configure.sh
+
+      [Install]
+      WantedBy=kubernetes.target
+
+  - path: /etc/systemd/system/kube-master-configuration.service
+    permissions: 0644
+    owner: root
+    content: |
+      [Unit]
+      Description=Configure kubernetes master
+      After=kube-master-installation.service
+
+      [Service]
+      Type=oneshot
+      RemainAfterExit=yes
+      ExecStartPre=/bin/chmod 544 /home/kubernetes/bin/configure-helper.sh
+      ExecStart=/home/kubernetes/bin/configure-helper.sh
+
+      [Install]
+      WantedBy=kubernetes.target
+
+  - path: /etc/systemd/system/kubelet-monitor.service
+    permissions: 0644
+    owner: root
+    content: |
+      [Unit]
+      Description=Kubernetes health monitoring for kubelet
+      After=kube-master-configuration.service
+
+      [Service]
+      Restart=always
+      RestartSec=10
+      RemainAfterExit=yes
+      RemainAfterExit=yes
+      ExecStartPre=/bin/chmod 544 /home/kubernetes/bin/health-monitor.sh
+      ExecStart=/home/kubernetes/bin/health-monitor.sh kubelet
+
+      [Install]
+      WantedBy=kubernetes.target
+
+  - path: /etc/systemd/system/kube-logrotate.timer
+    permissions: 0644
+    owner: root
+    content: |
+      [Unit]
+      Description=Hourly kube-logrotate invocation
+
+      [Timer]
+      OnCalendar=hourly
+
+      [Install]
+      WantedBy=kubernetes.target
+
+  - path: /etc/systemd/system/kube-logrotate.service
+    permissions: 0644
+    owner: root
+    content: |
+      [Unit]
+      Description=Kubernetes log rotation
+      After=kube-master-configuration.service
+
+      [Service]
+      Type=oneshot
+      ExecStart=-/usr/sbin/logrotate /etc/logrotate.conf
+
+      [Install]
+      WantedBy=kubernetes.target
+
+  - path: /etc/systemd/system/kubernetes.target
+    permissions: 0644
+    owner: root
+    content: |
+      [Unit]
+      Description=Kubernetes
+
+      [Install]
+      WantedBy=multi-user.target
+
+runcmd:
+  - systemctl daemon-reload
+  - systemctl enable containerd.service
+  - systemctl enable cri-containerd-installation.service
+  - systemctl enable cri-containerd.service
+  - systemctl enable cri-containerd.target
+  - systemctl enable kube-master-installation.service
+  - systemctl enable kube-master-configuration.service
+  - systemctl enable kubelet-monitor.service
+  - systemctl enable kube-logrotate.timer
+  - systemctl enable kube-logrotate.service
+  - systemctl enable kubernetes.target
+  - systemctl start kubernetes.target

--- a/test/e2e/node.yaml
+++ b/test/e2e/node.yaml
@@ -1,0 +1,204 @@
+#cloud-config
+
+write_files:
+# Setup cri-containerd.
+  - path: /etc/systemd/system/cri-containerd-installation.service
+    permissions: 0644
+    owner: root
+    content: |
+      # installed by cloud-init
+      [Unit]
+      Description=Download and install cri-containerd binaries and configurations.
+      After=network-online.target
+
+      [Service]
+      Type=oneshot
+      RemainAfterExit=yes
+      # cri-containerd requires the existence of cni config directory.
+      # TODO(random-liu): Eliminate the requirement in ocicni.
+      ExecStartPre=/bin/mkdir -p /etc/cni/net.d
+      ExecStartPre=/bin/mkdir -p /home/cri-containerd
+      ExecStartPre=/bin/mount --bind /home/cri-containerd /home/cri-containerd
+      ExecStartPre=/bin/mount -o remount,exec /home/cri-containerd
+      ExecStartPre=/usr/bin/curl --fail --retry 5 --retry-delay 3 --silent --show-error -H "X-Google-Metadata-Request: True" -o /home/cri-containerd/configure.sh http://metadata.google.internal/computeMetadata/v1/instance/attributes/cri-containerd-configure-sh
+      ExecStartPre=/bin/chmod 544 /home/cri-containerd/configure.sh
+      ExecStart=/home/cri-containerd/configure.sh
+
+      [Install]
+      WantedBy=cri-containerd.target
+
+  - path: /etc/containerd/config.toml
+    permissions: 0644
+    owner: root
+    content: |
+      # installed by cloud-init
+      oom_score = -999
+
+      [plugins.linux]
+        shim = "/home/cri-containerd/usr/local/bin/containerd-shim"
+        runtime = "/home/cri-containerd/usr/local/sbin/runc"
+
+  # TODO(random-liu): Add health monitor for containerd/cri-containerd.
+  - path: /etc/systemd/system/containerd.service
+    permissions: 0644
+    owner: root
+    content: |
+      # installed by cloud-init
+      [Unit]
+      Description=containerd container runtime
+      Documentation=https://containerd.io
+      After=cri-containerd-installation.service
+
+      [Service]
+      Restart=always
+      RestartSec=5
+      Delegate=yes
+      KillMode=process
+      ExecStartPre=/sbin/modprobe overlay
+      ExecStart=/home/cri-containerd/usr/local/bin/containerd --log-level debug
+
+      [Install]
+      WantedBy=cri-containerd.target
+
+  - path: /etc/systemd/system/cri-containerd.service
+    permissions: 0644
+    owner: root
+    content: |
+      # installed by cloud-init
+      [Unit]
+      Description=Kubernetes containerd CRI shim
+      Requires=network-online.target
+      After=cri-containerd-installation.service
+
+      [Service]
+      Restart=always
+      RestartSec=5
+      # Point to /home/kubernetes/bin where calico setup cni binary in kube-up.sh.
+      # Point to /etc/cni/net.d where calico put cni config in kube-up.sh.
+      ExecStart=/home/cri-containerd/usr/local/bin/cri-containerd \
+        --logtostderr --v=4 \
+        --network-bin-dir=/home/kubernetes/bin \
+        --network-conf-dir=/etc/cni/net.d
+
+      [Install]
+      WantedBy=cri-containerd.target
+
+  - path: /etc/systemd/system/cri-containerd.target
+    permissions: 0644
+    owner: root
+    content: |
+      [Unit]
+      Description=CRI Containerd
+
+      [Install]
+      WantedBy=kubernetes.target
+
+# Setup kubernetes.
+  - path: /etc/systemd/system/kube-node-installation.service
+    permissions: 0644
+    owner: root
+    content: |
+      [Unit]
+      Description=Download and install k8s binaries and configurations
+      After=network-online.target
+
+      [Service]
+      Type=oneshot
+      RemainAfterExit=yes
+      ExecStartPre=/bin/mkdir -p /home/kubernetes/bin
+      ExecStartPre=/bin/mount --bind /home/kubernetes/bin /home/kubernetes/bin
+      ExecStartPre=/bin/mount -o remount,exec /home/kubernetes/bin
+      ExecStartPre=/usr/bin/curl --fail --retry 5 --retry-delay 3 --silent --show-error	-H "X-Google-Metadata-Request: True" -o /home/kubernetes/bin/configure.sh http://metadata.google.internal/computeMetadata/v1/instance/attributes/configure-sh
+      ExecStartPre=/bin/chmod 544 /home/kubernetes/bin/configure.sh
+      ExecStart=/home/kubernetes/bin/configure.sh
+
+      [Install]
+      WantedBy=kubernetes.target
+
+  - path: /etc/systemd/system/kube-node-configuration.service
+    permissions: 0644
+    owner: root
+    content: |
+      [Unit]
+      Description=Configure kubernetes node
+      After=kube-node-installation.service
+
+      [Service]
+      Type=oneshot
+      RemainAfterExit=yes
+      ExecStartPre=/bin/chmod 544 /home/kubernetes/bin/configure-helper.sh
+      ExecStart=/home/kubernetes/bin/configure-helper.sh
+
+      [Install]
+      WantedBy=kubernetes.target
+
+  - path: /etc/systemd/system/kubelet-monitor.service
+    permissions: 0644
+    owner: root
+    content: |
+      [Unit]
+      Description=Kubernetes health monitoring for kubelet
+      After=kube-node-configuration.service
+
+      [Service]
+      Restart=always
+      RestartSec=10
+      RemainAfterExit=yes
+      RemainAfterExit=yes
+      ExecStartPre=/bin/chmod 544 /home/kubernetes/bin/health-monitor.sh
+      ExecStart=/home/kubernetes/bin/health-monitor.sh kubelet
+
+      [Install]
+      WantedBy=kubernetes.target
+
+  - path: /etc/systemd/system/kube-logrotate.timer
+    permissions: 0644
+    owner: root
+    content: |
+      [Unit]
+      Description=Hourly kube-logrotate invocation
+
+      [Timer]
+      OnCalendar=hourly
+
+      [Install]
+      WantedBy=kubernetes.target
+
+  - path: /etc/systemd/system/kube-logrotate.service
+    permissions: 0644
+    owner: root
+    content: |
+      [Unit]
+      Description=Kubernetes log rotation
+      After=kube-node-configuration.service
+
+      [Service]
+      Type=oneshot
+      ExecStart=-/usr/sbin/logrotate /etc/logrotate.conf
+
+      [Install]
+      WantedBy=kubernetes.target
+
+  - path: /etc/systemd/system/kubernetes.target
+    permissions: 0644
+    owner: root
+    content: |
+      [Unit]
+      Description=Kubernetes
+
+      [Install]
+      WantedBy=multi-user.target
+
+runcmd:
+  - systemctl daemon-reload
+  - systemctl enable containerd.service
+  - systemctl enable cri-containerd-installation.service
+  - systemctl enable cri-containerd.service
+  - systemctl enable cri-containerd.target
+  - systemctl enable kube-node-installation.service
+  - systemctl enable kube-node-configuration.service
+  - systemctl enable kubelet-monitor.service
+  - systemctl enable kube-logrotate.timer
+  - systemctl enable kube-logrotate.service
+  - systemctl enable kubernetes.target
+  - systemctl start kubernetes.target

--- a/test/e2e_node/image-config.yaml
+++ b/test/e2e_node/image-config.yaml
@@ -2,8 +2,8 @@ images:
   ubuntu:
     image: ubuntu-gke-1604-xenial-v20170420-1
     project: ubuntu-os-gke-cloud
-    metadata: "user-data<test/e2e_node/init.yaml,configure-sh<test/e2e_node/configure.sh"
+    metadata: "user-data<test/e2e_node/init.yaml,cri-containerd-configure-sh<test/configure.sh"
   cos-stable:
     image_regex: cos-stable-60-9592-84-0
     project: cos-cloud
-    metadata: "user-data<test/e2e_node/init.yaml,configure-sh<test/e2e_node/configure.sh,extra-init-sh<test/e2e_node/gci-init.sh,gci-update-strategy=update_disabled"
+    metadata: "user-data<test/e2e_node/init.yaml,cri-containerd-configure-sh<test/configure.sh,extra-init-sh<test/e2e_node/gci-init.sh,gci-update-strategy=update_disabled"

--- a/test/e2e_node/init.yaml
+++ b/test/e2e_node/init.yaml
@@ -16,7 +16,7 @@ write_files:
       ExecStartPre=/bin/mkdir -p /home/cri-containerd
       ExecStartPre=/bin/mount --bind /home/cri-containerd /home/cri-containerd
       ExecStartPre=/bin/mount -o remount,exec /home/cri-containerd
-      ExecStartPre=/usr/bin/curl --fail --retry 5 --retry-delay 3 --silent --show-error -H "X-Google-Metadata-Request: True" -o /home/cri-containerd/configure.sh http://metadata.google.internal/computeMetadata/v1/instance/attributes/configure-sh
+      ExecStartPre=/usr/bin/curl --fail --retry 5 --retry-delay 3 --silent --show-error -H "X-Google-Metadata-Request: True" -o /home/cri-containerd/configure.sh http://metadata.google.internal/computeMetadata/v1/instance/attributes/cri-containerd-configure-sh
       ExecStartPre=/bin/chmod 544 /home/cri-containerd/configure.sh
       ExecStart=/home/cri-containerd/configure.sh
 


### PR DESCRIPTION
This PR added cloud-init file and scripts for cri-containerd integration with `kube-up.sh`.

Also see https://github.com/kubernetes/kubernetes/pull/54964.