### PR TITLE
Also unpack image during creation.

### DIFF
--- a/pkg/server/container_create.go
+++ b/pkg/server/container_create.go
@@ -150,6 +150,7 @@ func (c *criContainerdService) CreateContainer(ctx context.Context, r *runtime.C
 	// Set snapshotter before any other options.
 	opts := []containerd.NewContainerOpts{
 		containerd.WithSnapshotter(c.config.ContainerdConfig.Snapshotter),
+		customopts.WithImageUnpack(image.Image),
 		// Prepare container rootfs. This is always writeable even if
 		// the container wants a readonly rootfs since we want to give
 		// the runtime (runc) a chance to modify (e.g. to create mount

--- a/pkg/server/restart.go
+++ b/pkg/server/restart.go
@@ -391,7 +391,7 @@ func loadImages(ctx context.Context, cImages []containerd.Image, provider conten
 		// Checking existence of top-level snapshot for each image being recovered.
 		if _, err := snapshotter.Stat(ctx, image.ChainID); err != nil {
 			glog.Warningf("Failed to stat the top-level snapshot for image %+v: %v", image, err)
-			continue
+			// TODO(random-liu): Consider whether we should try unpack here.
 		}
 		images = append(images, image)
 	}

--- a/pkg/server/sandbox_run.go
+++ b/pkg/server/sandbox_run.go
@@ -33,6 +33,7 @@ import (
 	"golang.org/x/sys/unix"
 	"k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
 
+	customopts "github.com/kubernetes-incubator/cri-containerd/pkg/opts"
 	sandboxstore "github.com/kubernetes-incubator/cri-containerd/pkg/store/sandbox"
 	"github.com/kubernetes-incubator/cri-containerd/pkg/util"
 )
@@ -143,6 +144,7 @@ func (c *criContainerdService) RunPodSandbox(ctx context.Context, r *runtime.Run
 
 	opts := []containerd.NewContainerOpts{
 		containerd.WithSnapshotter(c.config.ContainerdConfig.Snapshotter),
+		customopts.WithImageUnpack(image.Image),
 		containerd.WithNewSnapshot(id, image.Image),
 		containerd.WithSpec(spec, specOpts...),
 		containerd.WithContainerLabels(map[string]string{containerKindLabel: containerKindSandbox}),


### PR DESCRIPTION
To pull an image in containerd, we need to:
1) Download all contents;
2) Write image reference.
3) Unpack image into snapshotter.

Currently, if 3) fails, we don't rollback 1) and 2). If we don't put the image into our list, containerd will not garbage collect it, and the content will be left there forever.

We have 2 options for this:
1) Rollback 1) and 2) ourselves, which is a bit unreliable, expensive and complex.
2) Only do best effort unpack during image pulling, and always check snapshot existence and unpack image before container creation. This is more reliable, and is also recommended by https://github.com/containerd/containerd/pull/1567#issuecomment-333632696 @stevvooe 

This PR goes with option 2.

Signed-off-by: Lantao Liu <lantaol@google.com>