### PR TITLE
Add `--ipv4` in `curl`.

### DIFF
--- a/test/e2e_node/configure.sh
+++ b/test/e2e_node/configure.sh
@@ -40,7 +40,7 @@ fi
 
 # VERSION is the latest cri-containerd version got from cri-containerd gcs
 # bucket.
-VERSION=$(curl --fail --retry 5 --retry-delay 3 --silent --show-error \
+VERSION=$(curl -f --ipv4 --retry 6 --retry-delay 3 --silent --show-error \
   https://storage.googleapis.com/${DEPLOY_PATH}/latest)
 # TARBALL_GCS_PATH is the path to download cri-containerd tarball for node e2e.
 TARBALL_GCS_PATH="https://storage.googleapis.com/${DEPLOY_PATH}/cri-containerd-node-e2e-${VERSION}.tar.gz"


### PR DESCRIPTION
Sometimes retrieving latest version may timeout. https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-cri-containerd-node-e2e/237
```
Oct 26 19:44:01 tmp-node-e2e-f96385d2-cos-stable-60-9592-84-0 configure.sh[973]: ++ curl --fail --retry 5 --retry-delay 3 --silent --show-error https://storage.googleapis.com/cri-containerd-staging/latest
Oct 26 19:46:09 tmp-node-e2e-f96385d2-cos-stable-60-9592-84-0 configure.sh[973]: curl: (7) Failed to connect to storage.googleapis.com port 443: Connection timed out
Oct 26 19:46:09 tmp-node-e2e-f96385d2-cos-stable-60-9592-84-0 configure.sh[973]: + VERSION=
```

This PR adds `--ipv4` in `curl`, because:
1) Kubernetes scripts are all using `--ipv4` to download from gcs;
2) There seems to be some problem with curl download without specifying `--ipv4`. https://gist.github.com/joridos/673aa658e46a7342b154, https://stackoverflow.com/questions/28366402/failed-to-connect-to-www-googleapis-com-port-443-network-unreachable


Signed-off-by: Lantao Liu <lantaol@google.com>