### PR TITLE
Do not log container output in error log.

### DIFF
--- a/pkg/server/io/logger.go
+++ b/pkg/server/io/logger.go
@@ -83,7 +83,7 @@ func redirectLogs(path string, rc io.ReadCloser, wc io.WriteCloser, stream Strea
 		data := bytes.Join([][]byte{timestampBytes, streamBytes, lineBytes}, delimiterBytes)
 		data = append(data, eol)
 		if _, err := wc.Write(data); err != nil {
-			glog.Errorf("Fail to write log line %q: %v", data, err)
+			glog.Errorf("Fail to write %q log to log file %q: %v", stream, path, err)
 		}
 		// Continue on write error to drain the input.
 	}

--- a/test/e2e_node/init.yaml
+++ b/test/e2e_node/init.yaml
@@ -69,7 +69,7 @@ write_files:
       Restart=always
       RestartSec=5
       ExecStart=/home/cri-containerd/usr/local/bin/cri-containerd \
-        --alsologtostderr --v=4 \
+        --logtostderr --v=4 \
         --network-bin-dir=/home/cri-containerd/opt/cni/bin \
         --network-conf-dir=/home/cri-containerd/etc/cni/net.d
 


### PR DESCRIPTION
We should not log container output into our error log.
In my cluster, fluentd keeps logging error message, which fills up the disk. After that cri-containerd will not be able to redirect log for it because the disk is full.

In that case,
1) I see tons of error message including container output in cri-containerd.log, which is too spammy. So in this PR, I removed the container output from the error log.
2) I see `/tmp` directory is filled up very soon, because glog is logging into it by default. So in this PR I use `--logtostderr` instead of `--alsologtostderr` to avoid glog writing to `/tmp`.

Signed-off-by: Lantao Liu <lantaol@google.com>