### PR TITLE
Fix removing state recover.

### DIFF
--- a/pkg/server/container_start.go
+++ b/pkg/server/container_start.go
@@ -39,7 +39,7 @@ func (c *criContainerdService) StartContainer(ctx context.Context, r *runtime.St
 
 	var startErr error
 	// update container status in one transaction to avoid race with event monitor.
-	if err := container.Status.Update(func(status containerstore.Status) (containerstore.Status, error) {
+	if err := container.Status.UpdateSync(func(status containerstore.Status) (containerstore.Status, error) {
 		// Always apply status change no matter startContainer fails or not. Because startContainer
 		// may change container state no matter it fails or succeeds.
 		startErr = c.startContainer(ctx, container, &status)

--- a/pkg/server/events.go
+++ b/pkg/server/events.go
@@ -125,7 +125,7 @@ func (em *eventMonitor) handleEvent(evt *events.Envelope) {
 				// Move on to make sure container status is updated.
 			}
 		}
-		err = cntr.Status.Update(func(status containerstore.Status) (containerstore.Status, error) {
+		err = cntr.Status.UpdateSync(func(status containerstore.Status) (containerstore.Status, error) {
 			// If FinishedAt has been set (e.g. with start failure), keep as
 			// it is.
 			if status.FinishedAt != 0 {
@@ -151,7 +151,7 @@ func (em *eventMonitor) handleEvent(evt *events.Envelope) {
 			}
 			glog.Errorf("Failed to get container %q: %v", e.ContainerID, err)
 		}
-		err = cntr.Status.Update(func(status containerstore.Status) (containerstore.Status, error) {
+		err = cntr.Status.UpdateSync(func(status containerstore.Status) (containerstore.Status, error) {
 			status.Reason = oomExitReason
 			return status, nil
 		})

--- a/pkg/store/container/fake_status.go
+++ b/pkg/store/container/fake_status.go
@@ -38,6 +38,10 @@ func (f *fakeStatusStorage) Get() Status {
 	return f.status
 }
 
+func (f *fakeStatusStorage) UpdateSync(u UpdateFunc) error {
+	return f.Update(u)
+}
+
 func (f *fakeStatusStorage) Update(u UpdateFunc) error {
 	f.Lock()
 	defer f.Unlock()


### PR DESCRIPTION
In a test, I saw that we could never remove a container any more once containerd container removal returns an error.
```
E1029 23:59:48.015653    1035 container_remove.go:56] failed to reset removing state for container "9271ad01c1ef091260fca1b432128d98d3b6e40735f8e6b3d8f6d8d10d58ac56": failed to checkpoint status to "/var/lib/cri-containerd/containers/9271ad01c1ef091260fca1b432128d98d3b6e40735f8e6b3d8f6d8d10d58ac56/status": open /var/lib/cri-containerd/containers/9271ad01c1ef091260fca1b432128d98d3b6e40735f8e6b3d8f6d8d10d58ac56/.tmp-status551243121: no such file or directory
E1029 23:59:48.015675    1035 instrumented_service.go:176] RemoveContainer for "9271ad01c1ef091260fca1b432128d98d3b6e40735f8e6b3d8f6d8d10d58ac56" failed, error: failed to delete containerd container "9271ad01c1ef091260fca1b432128d98d3b6e40735f8e6b3d8f6d8d10d58ac56": context deadline exceeded: unknown
E1030 00:26:47.270788    1035 instrumented_service.go:176] RemoveContainer for "9271ad01c1ef091260fca1b432128d98d3b6e40735f8e6b3d8f6d8d10d58ac56" failed, error: failed to set removing state for container "9271ad01c1ef091260fca1b432128d98d3b6e40735f8e6b3d8f6d8d10d58ac56": container is already in removing state
```

The reason is that `removing` state could not be reset, because the on-disk container status has been removed, thus the reset function fails.

This PR:
1) Move container status deletion to be in front of container root directory deletion. Status checkpoint file is in container root directory. We may want to atomically remove the status file before we remove the whole root directory.
2) Move container status/root directory deletion after containerd container deletion. Actually it doesn't matter we delete them before or after containerd container. Restart recovery could handle both cases. However, it makes more sense to make sure that a containerd container always has status associated in its whole lifecycle.
3) Address a TODO to distinguish `UpdateSync` and `Update`. Actually in most cases, we just need the code to run in a `Update` transaction to avoid race, and don't actually update the on-disk status. We could use `Update` for this case in the future. **This also fixed the issue I mentioned above. With this PR, we'll only use `Update` to set/reset removing state, which doesn't include any disk operation, and won't be affected by container status/root directory removal.**

Signed-off-by: Lantao Liu <lantaol@google.com>