### PR TITLE
Add the missing container log path in container status.

### DIFF
--- a/pkg/server/container_status.go
+++ b/pkg/server/container_status.go
@@ -74,5 +74,6 @@ func toCRIContainerStatus(container containerstore.Container, imageRef string) *
 		Labels:      meta.Config.GetLabels(),
 		Annotations: meta.Config.GetAnnotations(),
 		Mounts:      meta.Config.GetMounts(),
+		LogPath:     meta.LogPath,
 	}
 }

--- a/pkg/server/container_status_test.go
+++ b/pkg/server/container_status_test.go
@@ -54,6 +54,7 @@ func getContainerStatusTestData() (*containerstore.Metadata, *containerstore.Sta
 		SandboxID: "test-sandbox-id",
 		Config:    config,
 		ImageRef:  "test-image-id",
+		LogPath:   "test-log-path",
 	}
 	status := &containerstore.Status{
 		Pid:       1234,
@@ -76,6 +77,7 @@ func getContainerStatusTestData() (*containerstore.Metadata, *containerstore.Sta
 		Labels:      config.GetLabels(),
 		Annotations: config.GetAnnotations(),
 		Mounts:      config.GetMounts(),
+		LogPath:     "test-log-path",
 	}
 
 	return metadata, status, image, expected


### PR DESCRIPTION
The field was introduced https://github.com/kubernetes/kubernetes/pull/45580, we should provide it because `crictl` is using it.
Signed-off-by: Lantao Liu <lantaol@google.com>