### PR TITLE
Add runtime cgroup and put containerd and cri-containerd into it.

### DIFF
--- a/contrib/ansible/cri-containerd.yaml
+++ b/contrib/ansible/cri-containerd.yaml
@@ -9,7 +9,28 @@
       when: ansible_distribution == "CentOS"
     - include: tasks/k8s.yaml # Contains tasks kubernetes component installation
     - include: tasks/binaries.yaml # Contains tasks for pulling containerd and cri-containerd components
-       
+
+    - name: "Create a directory for containerd config"
+      file: path=/etc/containerd state=directory
+
+    - name: "Add containerd config file"
+      blockinfile:
+        path: /etc/containerd/config.toml
+        create: yes
+        block: |
+          [cgroup]
+            path = "/runtime"
+
+    - name: "Create a directory for cri-containerd config"
+      file: path=/etc/cri-containerd state=directory
+
+    - name: "Add cri-containerd config file"
+      blockinfile:
+        path: /etc/cri-containerd/config.toml
+        create: yes
+        block: |
+          cgroup_path = "/runtime"
+
     - name: "Start Containerd"
       systemd: name=containerd daemon_reload=yes state=started enabled=yes
     
@@ -38,7 +59,7 @@
     - name: "Add runtime args in kubelet conf"
       lineinfile:
         dest: "/etc/systemd/system/kubelet.service.d/10-kubeadm.conf"
-        line: "Environment=\"KUBELET_EXTRA_ARGS= --container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=/var/run/cri-containerd.sock\""
+        line: "Environment=\"KUBELET_EXTRA_ARGS= --runtime-cgroups=/runtime --container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=/var/run/cri-containerd.sock\""
         insertafter: '\[Service\]'
       when: check_args.stdout == ""
     

--- a/contrib/ansible/tasks/binaries.yaml
+++ b/contrib/ansible/tasks/binaries.yaml
@@ -1,7 +1,8 @@
 ---
 - name: "Get Containerd and CRI-Containerd"
   unarchive:
-    src: "https://storage.googleapis.com/cri-containerd-release/cri-containerd-{{ cri_containerd_release_version }}.tar.gz"
+    # TODO change to cri-containerd-release before official release.
+    src: "https://storage.googleapis.com/cri-containerd-staging/cri-containerd-{{ cri_containerd_release_version }}.tar.gz"
     dest: "/"
     remote_src: yes
 

--- a/contrib/ansible/vars/vars.yaml
+++ b/contrib/ansible/vars/vars.yaml
@@ -1,6 +1,6 @@
 ---
 # TODO update official versions once they are available
-cri_containerd_release_version: 1.0.0-alpha.0
+cri_containerd_release_version: 1.0.0-alpha.0-84-ge57cb68
 cri_release_directory: /opt/cri-containerd/
 local_bin_dir: /usr/local/bin/
 local_sbin_dir: /usr/local/sbin/


### PR DESCRIPTION
Fixes https://github.com/kubernetes-incubator/cri-containerd/issues/194.

Put both `cri-containerd` and `containerd` into a runtime cgroup `/runtime` in ansible playbook. I'll do the same for `kube-up.sh`.

Signed-off-by: Lantao Liu <lantaol@google.com>