### PR TITLE
support get image by truncindex

### DIFF
--- a/pkg/server/container_status_test.go
+++ b/pkg/server/container_status_test.go
@@ -30,6 +30,7 @@ import (
 
 func getContainerStatusTestData() (*containerstore.Metadata, *containerstore.Status,
 	*imagestore.Image, *runtime.ContainerStatus) {
+	imageID := "sha256:1123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 	testID := "test-id"
 	config := &runtime.ContainerConfig{
 		Metadata: &runtime.ContainerMetadata{
@@ -53,7 +54,7 @@ func getContainerStatusTestData() (*containerstore.Metadata, *containerstore.Sta
 		Name:      "test-long-name",
 		SandboxID: "test-sandbox-id",
 		Config:    config,
-		ImageRef:  "test-image-id",
+		ImageRef:  imageID,
 		LogPath:   "test-log-path",
 	}
 	status := &containerstore.Status{
@@ -62,7 +63,7 @@ func getContainerStatusTestData() (*containerstore.Metadata, *containerstore.Sta
 		StartedAt: startedAt,
 	}
 	image := &imagestore.Image{
-		ID:          "test-image-id",
+		ID:          imageID,
 		RepoTags:    []string{"test-image-repo-tag"},
 		RepoDigests: []string{"test-image-repo-digest"},
 	}

--- a/pkg/server/image_list_test.go
+++ b/pkg/server/image_list_test.go
@@ -32,7 +32,7 @@ func TestListImages(t *testing.T) {
 	c := newTestCRIContainerdService()
 	imagesInStore := []imagestore.Image{
 		{
-			ID:          "test-id-1",
+			ID:          "sha256:1123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
 			ChainID:     "test-chainid-1",
 			RepoTags:    []string{"tag-a-1", "tag-b-1"},
 			RepoDigests: []string{"digest-a-1", "digest-b-1"},
@@ -42,7 +42,7 @@ func TestListImages(t *testing.T) {
 			},
 		},
 		{
-			ID:          "test-id-2",
+			ID:          "sha256:2123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
 			ChainID:     "test-chainid-2",
 			RepoTags:    []string{"tag-a-2", "tag-b-2"},
 			RepoDigests: []string{"digest-a-2", "digest-b-2"},
@@ -52,7 +52,7 @@ func TestListImages(t *testing.T) {
 			},
 		},
 		{
-			ID:          "test-id-3",
+			ID:          "sha256:3123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
 			ChainID:     "test-chainid-3",
 			RepoTags:    []string{"tag-a-3", "tag-b-3"},
 			RepoDigests: []string{"digest-a-3", "digest-b-3"},
@@ -64,21 +64,21 @@ func TestListImages(t *testing.T) {
 	}
 	expect := []*runtime.Image{
 		{
-			Id:          "test-id-1",
+			Id:          "sha256:1123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
 			RepoTags:    []string{"tag-a-1", "tag-b-1"},
 			RepoDigests: []string{"digest-a-1", "digest-b-1"},
 			Size_:       uint64(1000),
 			Username:    "root",
 		},
 		{
-			Id:          "test-id-2",
+			Id:          "sha256:2123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
 			RepoTags:    []string{"tag-a-2", "tag-b-2"},
 			RepoDigests: []string{"digest-a-2", "digest-b-2"},
 			Size_:       uint64(2000),
 			Uid:         &runtime.Int64Value{Value: 1234},
 		},
 		{
-			Id:          "test-id-3",
+			Id:          "sha256:3123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
 			RepoTags:    []string{"tag-a-3", "tag-b-3"},
 			RepoDigests: []string{"digest-a-3", "digest-b-3"},
 			Size_:       uint64(3000),


### PR DESCRIPTION
refer to #352
Signed-off-by: yanxuean <yan.xuean@zte.com.cn>

We get image by localResolve(). 
The localResolve receive these arguments as below:
1. imageID.   e.g.   sha256:xxxxxx
2. repotag.    e.g.   busybox:1.26
3. repodigest.   e.g.  busybox@sha256:xxxxx

Now we need it to support  the truncindex of imageID.
Because it is imageID that we store into imageStore, so at first the  localResolve() must treat the argument as the truncindex of imageID .

@mikebrow @Random-Liu 

