### PR TITLE
Update cri-containerd version to 1.0.0-alpha.1 in ansible.

### DIFF
--- a/contrib/ansible/tasks/binaries.yaml
+++ b/contrib/ansible/tasks/binaries.yaml
@@ -1,8 +1,7 @@
 ---
 - name: "Get Containerd and CRI-Containerd"
   unarchive:
-    # TODO change to cri-containerd-release before official release.
-    src: "https://storage.googleapis.com/cri-containerd-staging/cri-containerd-{{ cri_containerd_release_version }}.tar.gz"
+    src: "https://storage.googleapis.com/cri-containerd-release/cri-containerd-{{ cri_containerd_release_version }}.tar.gz"
     dest: "/"
     remote_src: yes
 

--- a/contrib/ansible/vars/vars.yaml
+++ b/contrib/ansible/vars/vars.yaml
@@ -1,6 +1,5 @@
 ---
-# TODO update official versions once they are available
-cri_containerd_release_version: 1.0.0-alpha.0-84-ge57cb68
+cri_containerd_release_version: 1.0.0-alpha.1
 cri_release_directory: /opt/cri-containerd/
 local_bin_dir: /usr/local/bin/
 local_sbin_dir: /usr/local/sbin/


### PR DESCRIPTION
Signed-off-by: Lantao Liu <lantaol@google.com>