### PR TITLE
Rename OWNERS assignees: to approvers:

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,3 +1,3 @@
-assignees:
+approvers:
   - Random-Liu
   - mikebrow


### PR DESCRIPTION
They are effectively the same, assignees is deprecated

ref: kubernetes/test-infra#3851