### PR TITLE
Rename release tarball for node e2e to cri-containerd-cni.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,6 +81,6 @@ jobs:
       script:
         - test "${TRAVIS_PULL_REQUEST}" != "false" && exit 0 || true
         - make push
-        # Build a tarball including CNI for node e2e.
-        - PUSH_VERSION=true make push TARBALL_PREFIX=cri-containerd-node-e2e INCLUDE_CNI=true
+        # Build a tarball including CNI.
+        - PUSH_VERSION=true make push TARBALL_PREFIX=cri-containerd-cni INCLUDE_CNI=true
       go: 1.8.x

--- a/test/e2e_node/build.sh
+++ b/test/e2e_node/build.sh
@@ -51,4 +51,4 @@ fi
 
 # Build and push node e2e tarball.
 PUSH_VERSION=true DEPLOY_DIR=${DEPLOY_DIR:-""} \
-  make push TARBALL_PREFIX=cri-containerd-node-e2e INCLUDE_CNI=true
+  make push TARBALL_PREFIX=cri-containerd-cni INCLUDE_CNI=true

--- a/test/e2e_node/configure.sh
+++ b/test/e2e_node/configure.sh
@@ -43,7 +43,7 @@ fi
 VERSION=$(curl -f --ipv4 --retry 6 --retry-delay 3 --silent --show-error \
   https://storage.googleapis.com/${DEPLOY_PATH}/latest)
 # TARBALL_GCS_PATH is the path to download cri-containerd tarball for node e2e.
-TARBALL_GCS_PATH="https://storage.googleapis.com/${DEPLOY_PATH}/cri-containerd-node-e2e-${VERSION}.tar.gz"
+TARBALL_GCS_PATH="https://storage.googleapis.com/${DEPLOY_PATH}/cri-containerd-cni-${VERSION}.tar.gz"
 # TARBALL is the name of the tarball after being downloaded.
 TARBALL="cri-containerd.tar.gz"
 


### PR DESCRIPTION
We'll also need tarball with CNI for master node in cluster e2e, so rename the tarball to `cri-containerd-cni`.

Signed-off-by: Lantao Liu <lantaol@google.com>