### PR TITLE
Get rid of spammy CNI log.

### DIFF
--- a/pkg/server/sandbox_status.go
+++ b/pkg/server/sandbox_status.go
@@ -85,6 +85,11 @@ func (c *criContainerdService) getIP(sandbox sandboxstore.Sandbox) (string, erro
 		return "", nil
 	}
 
+	// The network namespace has been closed.
+	if sandbox.NetNS == nil || sandbox.NetNS.Closed() {
+		return "", nil
+	}
+
 	podNetwork := ocicni.PodNetwork{
 		Name:         config.GetMetadata().GetName(),
 		Namespace:    config.GetMetadata().GetNamespace(),

--- a/pkg/store/sandbox/netns.go
+++ b/pkg/store/sandbox/netns.go
@@ -111,6 +111,13 @@ func (n *NetNS) Remove() error {
 	return nil
 }
 
+// Closed checks whether the network namespace has been closed.
+func (n *NetNS) Closed() bool {
+	n.Lock()
+	defer n.Unlock()
+	return n.closed
+}
+
 // GetPath returns network namespace path for sandbox container
 func (n *NetNS) GetPath() string {
 	n.Lock()


### PR DESCRIPTION
In test log, I see tons of:
```
 I1102 16:21:55.828275    1908 sandbox_status.go:102] getIP: failed to read sandbox "f20ab1e5e0d4e8f35a2fb38b8831d1b1c15393045f4416f307418caacec85180" IP from plugin: Unexpected command output nsenter: cannot open /var/run/netns/cni-82f4ccd1-72c7-495b-602e-eee9503a1d13: No such file or directory
```

When we try to get status of a stopped sandbox, the network namespace has been removed, and we'll see this error.

This doesn't harm, but cause confusion and also very spammy.

This PR checks whether network namespace is closed before we call `netPlugin.GetPodNetworkStatus`, which tries to `nsenter` into the network namespace.

Signed-off-by: Lantao Liu <lantaol@google.com>