### PR TITLE
Adding kube pod and container labels to containerd

### DIFF
--- a/pkg/server/container_create.go
+++ b/pkg/server/container_create.go
@@ -223,6 +223,7 @@ func (c *criContainerdService) CreateContainer(ctx context.Context, r *runtime.C
 	if seccompSpecOpts != nil {
 		specOpts = append(specOpts, seccompSpecOpts)
 	}
+	containerLabels := buildLabels(config.Labels, containerKindContainer)
 
 	opts = append(opts,
 		containerd.WithSpec(spec, specOpts...),
@@ -232,7 +233,7 @@ func (c *criContainerdService) CreateContainer(ctx context.Context, r *runtime.C
 				Runtime:       c.config.ContainerdConfig.RuntimeEngine,
 				RuntimeRoot:   c.config.ContainerdConfig.RuntimeRoot,
 				SystemdCgroup: c.config.SystemdCgroup}), // TODO (mikebrow): add CriuPath when we add support for pause
-		containerd.WithContainerLabels(map[string]string{containerKindLabel: containerKindContainer}),
+		containerd.WithContainerLabels(containerLabels),
 		containerd.WithContainerExtension(containerMetadataExtension, &meta))
 	var cntr containerd.Container
 	if cntr, err = c.client.NewContainer(ctx, id, opts...); err != nil {

--- a/pkg/server/helpers.go
+++ b/pkg/server/helpers.go
@@ -381,3 +381,13 @@ func isInCRIMounts(dst string, mounts []*runtime.Mount) bool {
 func filterLabel(k, v string) string {
 	return fmt.Sprintf("labels.%q==%q", k, v)
 }
+
+// buildLabel builds the labels from config to be passed to containerd
+func buildLabels(configLabels map[string]string, containerType string) map[string]string {
+	labels := make(map[string]string)
+	for k, v := range configLabels {
+		labels[k] = v
+	}
+	labels[containerKindLabel] = containerType
+	return labels
+}

--- a/pkg/server/sandbox_run.go
+++ b/pkg/server/sandbox_run.go
@@ -143,12 +143,14 @@ func (c *criContainerdService) RunPodSandbox(ctx context.Context, r *runtime.Run
 		specOpts = append(specOpts, seccompSpecOpts)
 	}
 
+	sandboxLabels := buildLabels(config.Labels, containerKindSandbox)
+
 	opts := []containerd.NewContainerOpts{
 		containerd.WithSnapshotter(c.config.ContainerdConfig.Snapshotter),
 		customopts.WithImageUnpack(image.Image),
 		containerd.WithNewSnapshot(id, image.Image),
 		containerd.WithSpec(spec, specOpts...),
-		containerd.WithContainerLabels(map[string]string{containerKindLabel: containerKindSandbox}),
+		containerd.WithContainerLabels(sandboxLabels),
 		containerd.WithContainerExtension(sandboxMetadataExtension, &sandbox.Metadata),
 		containerd.WithRuntime(
 			c.config.ContainerdConfig.Runtime,


### PR DESCRIPTION
Currently we have the pod and container labels part of
containerd metadata extensions. However for third party users
like cadvisor that depend on standard kube labels will need
to be aware of the way metadata is stored in containerd to
fetch the labels.

Signed-off-by: abhi <abhi@docker.com>