### PR TITLE
Various fixes for container streaming.

### DIFF
--- a/pkg/ioutil/read_closer.go
+++ b/pkg/ioutil/read_closer.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ioutil
+
+import (
+	"io"
+	"sync"
+)
+
+// writeCloseInformer wraps a reader with a close function.
+type wrapReadCloser struct {
+	// TODO(random-liu): Evaluate whether the lock introduces
+	// performance regression.
+	sync.RWMutex
+	r      io.Reader
+	closed bool
+}
+
+// NewWrapReadCloser creates a wrapReadCloser from a reader.
+func NewWrapReadCloser(r io.Reader) io.ReadCloser {
+	return &wrapReadCloser{r: r}
+}
+
+// Read reads up to len(p) bytes into p.
+func (w *wrapReadCloser) Read(p []byte) (int, error) {
+	w.RLock()
+	defer w.RUnlock()
+	if w.closed {
+		return 0, io.EOF
+	}
+	return w.r.Read(p)
+}
+
+// Close closes read closer.
+func (w *wrapReadCloser) Close() error {
+	w.Lock()
+	defer w.Unlock()
+	w.closed = true
+	return nil
+}

--- a/pkg/ioutil/read_closer_test.go
+++ b/pkg/ioutil/read_closer_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ioutil
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWrapReadCloser(t *testing.T) {
+	buf := bytes.NewBufferString("abc")
+
+	rc := NewWrapReadCloser(buf)
+	dst := make([]byte, 1)
+	n, err := rc.Read(dst)
+	assert.Equal(t, 1, n)
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("a"), dst)
+
+	n, err = rc.Read(dst)
+	assert.Equal(t, 1, n)
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("b"), dst)
+
+	rc.Close()
+	n, err = rc.Read(dst)
+	assert.Equal(t, 0, n)
+	assert.Equal(t, io.EOF, err)
+	assert.Equal(t, []byte("b"), dst)
+}


### PR DESCRIPTION
I've tried cluster e2e in my own cluster, and we could pass most of the test.

There are around 5 test failure I got, this PR fixes 2 of them.

This PR:
1) Add `TERM=xterm` env when do container exec. Sometimes the original container may not have `tty`, thus no `TERM=xterm`. But if we exec with tty, we should add this.
2) Fixes https://github.com/kubernetes-incubator/cri-containerd/issues/354. Moved resize handling after task start, so that we won't miss the first resize request. https://github.com/kubernetes/kubernetes/pull/47991 @abhi Could you verify whether you still have the exec problem after this PR is merged?
3) Fix a case that `Attach` may hang. Previously after stdout/stdin is closed, we close the reader side of stdin. However, that doesn't stop `io.Copy` if the writer side doesn't write any new thing. In this PR, we close the writer side instead.
4) Fix `StdinOnce`. Copy [docker's behavior](https://github.com/moby/moby/blob/v17.05.0-ce/container/stream/attach.go#L104-L114) for `StdinOnce`. 2 kubectl tests are relying on this behavior.

Signed-off-by: Lantao Liu <lantaol@google.com>