### PR TITLE
Remove comment about whether other paths should be read only with root

### DIFF
--- a/pkg/server/container_create.go
+++ b/pkg/server/container_create.go
@@ -554,8 +554,6 @@ func setOCIDevicesPrivileged(g *generate.Generator) error {
 }
 
 // addOCIBindMounts adds bind mounts.
-// TODO(random-liu): Figure out whether we need to change all CRI mounts to readonly when
-// rootfs is readonly. (https://github.com/moby/moby/blob/master/daemon/oci_linux.go)
 func (c *criContainerdService) addOCIBindMounts(g *generate.Generator, mounts []*runtime.Mount, mountLabel string) error {
 	// Mount cgroup into the container as readonly, which inherits docker's behavior.
 	g.AddCgroupsMount("ro") // nolint: errcheck


### PR DESCRIPTION
Since https://github.com/moby/moby/pull/35344 we clarified that this behaviour
was a mistake, and the read only flag should just apply to the actual rootfs,
so it corresponds to the OCI read-only option. Other mounts may be able to be
adjusted by re-specifying them or other means but this is unrelated.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>