### PR TITLE
Cleanup config.

### DIFF
--- a/cmd/cri-containerd/options/options.go
+++ b/cmd/cri-containerd/options/options.go
@@ -58,9 +58,9 @@ type ContainerdConfig struct {
 // CniConfig contains config related to cni
 type CniConfig struct {
 	// NetworkPluginBinDir is the directory in which the binaries for the plugin is kept.
-	NetworkPluginBinDir string `toml:"bin_dir" json:"networkPluginBinDir,omitempty"`
+	NetworkPluginBinDir string `toml:"bin_dir" json:"binDir,omitempty"`
 	// NetworkPluginConfDir is the directory in which the admin places a CNI conf.
-	NetworkPluginConfDir string `toml:"conf_dir" json:"networkPluginConfDir,omitempty"`
+	NetworkPluginConfDir string `toml:"conf_dir" json:"confDir,omitempty"`
 }
 
 // Config contains cri-containerd toml config
@@ -68,7 +68,7 @@ type Config struct {
 	// ContainerdConfig contains config related to containerd
 	ContainerdConfig `toml:"containerd" json:"containerd,omitempty"`
 	// CniConfig contains config related to cni
-	CniConfig `toml:"cni" json:"cniConfig,omitempty"`
+	CniConfig `toml:"cni" json:"cni,omitempty"`
 	// SocketPath is the path to the socket which cri-containerd serves on.
 	SocketPath string `toml:"socket_path" json:"socketPath,omitempty"`
 	// RootDir is the root directory path for managing cri-containerd files


### PR DESCRIPTION
After this change:
```console
# crictl info
{
  "status": {
    "conditions": [
      {
        "type": "RuntimeReady",
        "status": true
      },
      {
        "type": "NetworkReady",
        "status": true
      }
    ]
  },
  "config": {
    "containerd": {
      "rootDir": "/var/lib/containerd",
      "snapshotter": "overlayfs",
      "endpoint": "/run/containerd/containerd.sock",
      "runtime": "io.containerd.runtime.v1.linux"
    },
    "cni": {
      "pluginBinDir": "/opt/cni/bin",
      "pluginConfDir": "/etc/cni/net.d"
    },
    "socketPath": "/var/run/cri-containerd.sock",
    "rootDir": "/var/lib/cri-containerd",
    "streamServerPort": "10010",
    "sandboxImage": "gcr.io/google_containers/pause:3.0",
    "statsCollectPeriod": 10,
    "oomScore": -999,
    "enableProfiling": true,
    "profilingPort": "10011",
    "profilingAddress": "127.0.0.1"
  }
}
```
Signed-off-by: Lantao Liu <lantaol@google.com>