### PR TITLE
Keep stdin open instead of opening when use it.

### DIFF
--- a/pkg/ioutil/writer_group.go
+++ b/pkg/ioutil/writer_group.go
@@ -20,8 +20,6 @@ import (
 	"errors"
 	"io"
 	"sync"
-
-	"github.com/golang/glog"
 )
 
 // WriterGroup is a group of writers. Writer could be dynamically
@@ -73,11 +71,7 @@ func (g *WriterGroup) Write(p []byte) (int, error) {
 	defer g.mu.Unlock()
 	for k, w := range g.writers {
 		n, err := w.Write(p)
-		if err != nil {
-			glog.Errorf("Writer %q write error: %v", k, err)
-		} else if len(p) != n {
-			glog.Errorf("Writer %q short write error", k)
-		} else {
+		if err == nil && len(p) == n {
 			continue
 		}
 		// The writer is closed or in bad state, remove it.

--- a/pkg/server/container_create.go
+++ b/pkg/server/container_create.go
@@ -175,7 +175,7 @@ func (c *criContainerdService) CreateContainer(ctx context.Context, r *runtime.C
 	}
 
 	containerIO, err := cio.NewContainerIO(id,
-		cio.WithStdin(config.GetStdin()),
+		cio.WithStdinOpen(config.GetStdin()),
 		cio.WithTerminal(config.GetTty()),
 		cio.WithRootDir(containerRootDir),
 	)

--- a/pkg/server/restart.go
+++ b/pkg/server/restart.go
@@ -202,7 +202,7 @@ func loadContainer(ctx context.Context, cntr containerd.Container, containerDir 
 			// cri-containerd got restarted just during that. In that case, we still
 			// treat the container as `CREATED`.
 			containerIO, err = cio.NewContainerIO(id,
-				cio.WithStdin(meta.Config.GetStdin()),
+				cio.WithStdinOpen(meta.Config.GetStdin()),
 				cio.WithTerminal(meta.Config.GetTty()),
 			)
 			if err != nil {


### PR DESCRIPTION
Fix test `Simple pod should support inline execution and attach`.
https://k8s-testgrid.appspot.com/sig-node-containerd#e2e-gci

The test leaves stdin open after:
``` console
$ kubectl --server=https://localhost:6443 --kubeconfig=/var/run/kubernetes/admin.kubeconfig --namespace=e2e-tests-kubectl-7sgm7 run run-test-3 --image=busybox --restart=OnFailure --attach=true --leave-stdin-open=true --stdin -- sh -c cat && echo 'stdin closed'
```
and then assumes that `stdin closed` SHOULD NOT be printed.

However, with current cri-containerd, we open and close the stdin pipe, which seems to trigger `cat` to return, although I don't know why...
I observed that:
1) If we open the stdin fifo writer side after containerd opens the stdin fifo reader side. When we close it, `cat` will return.
2) If we open the stdin fifo writer side before containerd opens the stdin fifo reader side. When we close it, `cat` won't return. Thus we still need the `CloseStdio` function to close the containerd side.

Anyway, this PR changes the behavior to be the same with Docker, and fixes the test.

Signed-off-by: Lantao Liu <lantaol@google.com>