### PR TITLE
Print full container spec for debugging.

### DIFF
--- a/pkg/server/container_create.go
+++ b/pkg/server/container_create.go
@@ -31,6 +31,7 @@ import (
 	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/typeurl"
+	"github.com/davecgh/go-spew/spew"
 	"github.com/golang/glog"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/opencontainers/runc/libcontainer/devices"
@@ -146,7 +147,7 @@ func (c *criContainerdService) CreateContainer(ctx context.Context, r *runtime.C
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate container %q spec: %v", id, err)
 	}
-	glog.V(4).Infof("Container spec: %+v", spec)
+	glog.V(4).Infof("Container %q spec: %#+v", id, spew.NewFormatter(spec))
 
 	// Set snapshotter before any other options.
 	opts := []containerd.NewContainerOpts{


### PR DESCRIPTION
Old:
```
I1111 08:58:01.855644   21354 container_create.go:149] Container spec: &{Version:1.0.0 Process:0xc420761ad0 Root:0xc420713d00 Hostname: Mounts:[{Destination:/proc Type:proc Source:proc Options:[]} {Destination:/dev Type:tmpfs Source:tmpfs Options:[nosuid strictatime mode=755 size=65536k]} {Destination:/dev/pts Type:devpts Source:devpts Options:[nosuid noexec newinstance ptmxmode=0666 mode=0620 gid=5]} {Destination:/dev/shm Type:tmpfs Source:shm Options:[nosuid noexec nodev mode=1777 size=65536k]} {Destination:/dev/mqueue Type:mqueue Source:mqueue Options:[nosuid noexec nodev]} {Destination:/sys Type:sysfs Source:sysfs Options:[nosuid noexec nodev ro]} {Destination:/sys/fs/cgroup Type:cgroup Source:cgroup Options:[nosuid noexec nodev relatime ro]} {Destination:/etc/resolv.conf Type:bind Source:/var/lib/cri-containerd/sandboxes/892051e9cf93b35668fc967730c95f47d3d7ad0876f6cb1037dd4af24cad604f/resolv.conf Options:[rbind rprivate rw]} {Destination:/dev/shm Type:bind Source:/var/lib/cri-containerd/sandboxes/892051e9cf93b35668fc967730c95f47d3d7ad0876f6cb1037dd4af24cad604f/shm Options:[rbind rprivate rw]} {Destination:/etc/configmap-volume Type:bind Source:/var/lib/kubelet/pods/6a5f323c-c6be-11e7-a42c-42010a140048/volumes/kubernetes.io~configmap/configmap-volume Options:[rbind rprivate ro]} {Destination:/etc/hosts Type:bind Source:/var/lib/kubelet/pods/6a5f323c-c6be-11e7-a42c-42010a140048/etc-hosts Options:[rbind rprivate rw]} {Destination:/dev/termination-log Type:bind Source:/var/lib/kubelet/pods/6a5f323c-c6be-11e7-a42c-42010a140048/containers/configmap-volume-test/d0651fc6 Options:[rbind rprivate rw]}] Hooks:<nil> Annotations:map[] Linux:0xc42073c8c0 Solaris:<nil> Windows:<nil>} 
```
New:
```
I1113 23:28:41.165840   32057 container_create.go:150] Container spec: (*specs.Spec)(0xc42020a770){Version:(string)1.0.0 Process:(*specs.Process)(0xc4203449c0){Terminal:(bool)false ConsoleSize:(*specs.Box)<nil> User:(specs.User){UID:(uint32)0 GID:(uint32)0 AdditionalGids:([]uint32)[1001] Username:(string)} Args:([]string)[/mounttest --file_content=/etc/configmap-volume/path/to/data-2 --file_mode=/etc/configmap-volume/path/to/data-2] Env:([]string)[PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin KUBERNETES_SERVICE_HOST=10.0.0.1 KUBERNETES_SERVICE_PORT=443 KUBERNETES_SERVICE_PORT_HTTPS=443 KUBERNETES_PORT=tcp://10.0.0.1:443 KUBERNETES_PORT_443_TCP=tcp://10.0.0.1:443 KUBERNETES_PORT_443_TCP_PROTO=tcp KUBERNETES_PORT_443_TCP_PORT=443 KUBERNETES_PORT_443_TCP_ADDR=10.0.0.1] Cwd:(string)/ Capabilities:(*specs.LinuxCapabilities)(0xc420547100){Bounding:([]string)[CAP_CHOWN CAP_DAC_OVERRIDE CAP_FSETID CAP_FOWNER CAP_MKNOD CAP_NET_RAW CAP_SETGID CAP_SETUID CAP_SETFCAP CAP_SETPCAP CAP_NET_BIND_SERVICE CAP_SYS_CHROOT CAP_KILL CAP_AUDIT_WRITE] Effective:([]string)[CAP_CHOWN CAP_DAC_OVERRIDE CAP_FSETID CAP_FOWNER CAP_MKNOD CAP_NET_RAW CAP_SETGID CAP_SETUID CAP_SETFCAP CAP_SETPCAP CAP_NET_BIND_SERVICE CAP_SYS_CHROOT CAP_KILL CAP_AUDIT_WRITE] Inheritable:([]string)[CAP_CHOWN CAP_DAC_OVERRIDE CAP_FSETID CAP_FOWNER CAP_MKNOD CAP_NET_RAW CAP_SETGID CAP_SETUID CAP_SETFCAP CAP_SETPCAP CAP_NET_BIND_SERVICE CAP_SYS_CHROOT CAP_KILL CAP_AUDIT_WRITE] Permitted:([]string)[CAP_CHOWN CAP_DAC_OVERRIDE CAP_FSETID CAP_FOWNER CAP_MKNOD CAP_NET_RAW CAP_SETGID CAP_SETUID CAP_SETFCAP CAP_SETPCAP CAP_NET_BIND_SERVICE CAP_SYS_CHROOT CAP_KILL CAP_AUDIT_WRITE] Ambient:([]string)<nil>} Rlimits:([]specs.POSIXRlimit)[{Type:(string)RLIMIT_NOFILE Hard:(uint64)1024 Soft:(uint64)1024}] NoNewPrivileges:(bool)false ApparmorProfile:(string) OOMScoreAdj:(*int)(0xc4204c6200)1000 SelinuxLabel:(string)} Root:(*specs.Root)(0xc420147580){Path:(string)rootfs Readonly:(bool)false} Hostname:(string) Mounts:([]specs.Mount)[{Destination:(string)/proc Type:(string)proc Source:(string)proc Options:([]string)<nil>} {Destination:(string)/dev Type:(string)tmpfs Source:(string)tmpfs Options:([]string)[nosuid strictatime mode=755 size=65536k]} {Destination:(string)/dev/pts Type:(string)devpts Source:(string)devpts Options:([]string)[nosuid noexec newinstance ptmxmode=0666 mode=0620 gid=5]} {Destination:(string)/dev/shm Type:(string)tmpfs Source:(string)shm Options:([]string)[nosuid noexec nodev mode=1777 size=65536k]} {Destination:(string)/dev/mqueue Type:(string)mqueue Source:(string)mqueue Options:([]string)[nosuid noexec nodev]} {Destination:(string)/sys Type:(string)sysfs Source:(string)sysfs Options:([]string)[nosuid noexec nodev ro]} {Destination:(string)/sys/fs/cgroup Type:(string)cgroup Source:(string)cgroup Options:([]string)[nosuid noexec nodev relatime ro]} {Destination:(string)/etc/resolv.conf Type:(string)bind Source:(string)/var/lib/cri-containerd/sandboxes/2cd13d2e60dfb6e40b1ce4bbef4c9f457c5be324caff18b35abc7495226bb941/resolv.conf Options:([]string)[rbind rprivate rw]} {Destination:(string)/dev/shm Type:(string)bind Source:(string)/var/lib/cri-containerd/sandboxes/2cd13d2e60dfb6e40b1ce4bbef4c9f457c5be324caff18b35abc7495226bb941/shm Options:([]string)[rbind rprivate rw]} {Destination:(string)/etc/configmap-volume Type:(string)bind Source:(string)/var/lib/kubelet/pods/60deb2ca-c8ca-11e7-8e36-42010af00002/volumes/kubernetes.io~configmap/configmap-volume Options:([]string)[rbind rprivate ro]} {Destination:(string)/var/run/secrets/kubernetes.io/serviceaccount Type:(string)bind Source:(string)/var/lib/kubelet/pods/60deb2ca-c8ca-11e7-8e36-42010af00002/volumes/kubernetes.io~secret/default-token-x9n6j Options:([]string)[rbind rprivate ro]} {Destination:(string)/etc/hosts Type:(string)bind Source:(string)/var/lib/kubelet/pods/60deb2ca-c8ca-11e7-8e36-42010af00002/etc-hosts Options:([]string)[rbind rprivate rw]} {Destination:(string)/dev/termination-log Type:(string)bind Source:(string)/var/lib/kubelet/pods/60deb2ca-c8ca-11e7-8e36-42010af00002/containers/configmap-volume-test/75bf5597 Options:([]string)[rbind rprivate rw]}] Hooks:(*specs.Hooks)<nil> Annotations:(map[string]string)<nil> Linux:(*specs.Linux)(0xc4200127e0){UIDMappings:([]specs.LinuxIDMapping)<nil> GIDMappings:([]specs.LinuxIDMapping)<nil> Sysctl:(map[string]string)<nil> Resources:(*specs.LinuxResources)(0xc420153bc0){Devices:([]specs.LinuxDeviceCgroup)[{Allow:(bool)false Type:(string) Major:(*int64)<nil> Minor:(*int64)<nil> Access:(string)rwm}] Memory:(*specs.LinuxMemory)(0xc420617a00){Limit:(*int64)(0xc4204c61f8)0 Reservation:(*int64)<nil> Swap:(*int64)<nil> Kernel:(*int64)<nil> KernelTCP:(*int64)<nil> Swappiness:(*uint64)<nil> DisableOOMKiller:(*bool)<nil>} CPU:(*specs.LinuxCPU)(0xc4206dd450){Shares:(*uint64)(0xc4204c61f0)2 Quota:(*int64)(0xc4204c61e8)0 Period:(*uint64)(0xc4204c61e0)0 RealtimeRuntime:(*int64)<nil> RealtimePeriod:(*uint64)<nil> Cpus:(string) Mems:(string)} Pids:(*specs.LinuxPids)<nil> BlockIO:(*specs.LinuxBlockIO)<nil> HugepageLimits:([]specs.LinuxHugepageLimit)<nil> Network:(*specs.LinuxNetwork)<nil>} CgroupsPath:(string)/kubepods/besteffort/pod60deb2ca-c8ca-11e7-8e36-42010af00002/b1b147329cdfaff2f413973f11b8098b1d4f7205ad56011b585fb9934655576d Namespaces:([]specs.LinuxNamespace)[{Type:(specs.LinuxNamespaceType)pid Path:(string)} {Type:(specs.LinuxNamespaceType)ipc Path:(string)/proc/1083/ns/ipc} {Type:(specs.LinuxNamespaceType)uts Path:(string)/proc/1083/ns/uts} {Type:(specs.LinuxNamespaceType)mount Path:(string)} {Type:(specs.LinuxNamespaceType)network Path:(string)/proc/1083/ns/net}] Devices:([]specs.LinuxDevice)<nil> Seccomp:(*specs.LinuxSeccomp)<nil> RootfsPropagation:(string) MaskedPaths:([]string)[/proc/kcore /proc/latency_stats /proc/timer_list /proc/timer_stats /proc/sched_debug /sys/firmware /proc/scsi] ReadonlyPaths:([]string)[/proc/asound /proc/bus /proc/fs /proc/irq /proc/sys /proc/sysrq-trigger] MountLabel:(string) IntelRdt:(*specs.LinuxIntelRdt)<nil>} Solaris:(*specs.Solaris)<nil> Windows:(*specs.Windows)<nil>}  
```
Signed-off-by: Lantao Liu <lantaol@google.com>