### PR TITLE
Fix data race.

### DIFF
--- a/pkg/server/container_create.go
+++ b/pkg/server/container_create.go
@@ -442,11 +442,12 @@ func setOCIProcessArgs(g *generate.Generator, config *runtime.ContainerConfig, i
 	// The following logic is migrated from https://github.com/moby/moby/blob/master/daemon/commit.go
 	// TODO(random-liu): Clearly define the commands overwrite behavior.
 	if len(command) == 0 {
+		// Copy array to avoid data race.
 		if len(args) == 0 {
-			args = imageConfig.Cmd
+			args = append([]string{}, imageConfig.Cmd...)
 		}
 		if command == nil {
-			command = imageConfig.Entrypoint
+			command = append([]string{}, imageConfig.Entrypoint...)
 		}
 	}
 	if len(command) == 0 && len(args) == 0 {


### PR DESCRIPTION
Many integration test failures are caused by this. It's very easy to reproduce by running volume e2e test with parallelism 30.

Original I thought `append(command, args...)` is a read only operation, but it seems not.
When different containers using the same image are created at the same time, they'll access the command and args at the same time, `append(command, args...)` seems to corrupt the underlying memory block.

With this fix, I could not reproduce the failure any more.

Signed-off-by: Lantao Liu <lantaol@google.com>