### PR TITLE
Move verify to kubernetes test-infra.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,13 +48,11 @@ jobs:
       script:
         - make install.tools
         - make .gitvalidation
-        - make verify
         - make binaries
       go: 1.9.x
     - script:
         - make install.tools
         - make .gitvalidation
-        - make verify
         - make binaries
       go: tip
     - stage: Test

--- a/test/verify.sh
+++ b/test/verify.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script is used to build and upload cri-containerd in gcr.io/k8s-testimages/kubekins-e2e.
+
+set -o xtrace
+set -o errexit
+set -o nounset
+set -o pipefail
+
+ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"/..
+cd "${ROOT}"
+
+make install.tools
+make verify


### PR DESCRIPTION
Fixes https://github.com/kubernetes-incubator/cri-containerd/issues/418.

`make verify` usually OOMs after upgrading to golang 1.9. e.g. https://travis-ci.org/kubernetes-incubator/cri-containerd/jobs/303420847.

This PR configure `gometalinter` to only run 2 linters at the same time to reduce memory usage. By default it's 8, and I tried on my workstation, each linter sometimes take more than 1 GB RES memory.

Signed-off-by: Lantao Liu <lantaol@google.com>