### PR TITLE
contrib instead of contib

### DIFF
--- a/contrib/ansible/README.md
+++ b/contrib/ansible/README.md
@@ -27,7 +27,7 @@ $ cat hosts
 At this point, the ansible playbook should be able to ssh into the machines in the hosts file.
 ```console
 git clone https://github.com/kubernetes-incubator/cri-containerd
-cd ./cri-containerd/contib/ansible
+cd ./cri-containerd/contrib/ansible
 ansible-playbook -i hosts cri-containerd.yaml
 ```
 A typical cloud login might have a username and private key file, in which case the following can be used:


### PR DESCRIPTION
Replaced error on Ansible README.