### PR TITLE
Remove explicit unpack on all container creates

### DIFF
--- a/pkg/server/container_create.go
+++ b/pkg/server/container_create.go
@@ -152,13 +152,12 @@ func (c *criContainerdService) CreateContainer(ctx context.Context, r *runtime.C
 	// Set snapshotter before any other options.
 	opts := []containerd.NewContainerOpts{
 		containerd.WithSnapshotter(c.config.ContainerdConfig.Snapshotter),
-		customopts.WithImageUnpack(image.Image),
 		// Prepare container rootfs. This is always writeable even if
 		// the container wants a readonly rootfs since we want to give
 		// the runtime (runc) a chance to modify (e.g. to create mount
 		// points corresponding to spec.Mounts) before making the
 		// rootfs readonly (requested by spec.Root.Readonly).
-		containerd.WithNewSnapshot(id, image.Image),
+		customopts.WithNewSnapshot(id, image.Image),
 	}
 
 	if len(volumeMounts) > 0 {

--- a/pkg/server/sandbox_run.go
+++ b/pkg/server/sandbox_run.go
@@ -148,8 +148,7 @@ func (c *criContainerdService) RunPodSandbox(ctx context.Context, r *runtime.Run
 
 	opts := []containerd.NewContainerOpts{
 		containerd.WithSnapshotter(c.config.ContainerdConfig.Snapshotter),
-		customopts.WithImageUnpack(image.Image),
-		containerd.WithNewSnapshot(id, image.Image),
+		customopts.WithNewSnapshot(id, image.Image),
 		containerd.WithSpec(spec, specOpts...),
 		containerd.WithContainerLabels(sandboxLabels),
 		containerd.WithContainerExtension(sandboxMetadataExtension, &sandbox.Metadata),


### PR DESCRIPTION
This only performs an unpack if there is an error when creating the
container (and only if it's a "not found' error) since it should already
be unpacked.