### PR TITLE
should specify snapshotter for Pull

### DIFF
--- a/pkg/server/image_pull.go
+++ b/pkg/server/image_pull.go
@@ -100,6 +100,7 @@ func (c *criContainerdService) PullImage(ctx context.Context, r *runtime.PullIma
 
 	// TODO(mikebrow): add truncIndex for image id
 	image, err := c.client.Pull(ctx, ref,
+		containerd.WithPullSnapshotter(c.config.ContainerdConfig.Snapshotter),
 		containerd.WithSchema1Conversion,
 		containerd.WithResolver(resolver),
 	)


### PR DESCRIPTION
Signed-off-by: yanxuean <yan.xuean@zte.com.cn>

Now we don't specify snapshotter for client.Pull. so the containerd use default snapshotter.
When the user don't specify default snapshotter(overlayfs), there will be a problem.
