### PR TITLE
Setting containerd shim cgroup same as pod cgroup

### DIFF
--- a/pkg/opts/task.go
+++ b/pkg/opts/task.go
@@ -1,0 +1,22 @@
+package opts
+
+import (
+	"context"
+
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/linux/runctypes"
+)
+
+// WithContainerdShimCgroup returns function that sets the containerd
+// shim cgroup path
+func WithContainerdShimCgroup(path string) containerd.NewTaskOpts {
+	return func(_ context.Context, _ *containerd.Client, r *containerd.TaskInfo) error {
+		r.Options = &runctypes.CreateOptions{
+			ShimCgroup: path,
+		}
+		return nil
+	}
+}
+
+//TODO: Since Options is an interface different WithXXX will be needed to set different
+// combinations of CreateOptions.

--- a/pkg/server/container_start.go
+++ b/pkg/server/container_start.go
@@ -27,6 +27,7 @@ import (
 	"golang.org/x/net/context"
 	"k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
 
+	criopts "github.com/kubernetes-incubator/cri-containerd/pkg/opts"
 	cio "github.com/kubernetes-incubator/cri-containerd/pkg/server/io"
 	containerstore "github.com/kubernetes-incubator/cri-containerd/pkg/store/container"
 )
@@ -126,7 +127,11 @@ func (c *criContainerdService) startContainer(ctx context.Context,
 		return cntr.IO, nil
 	}
 
-	task, err := container.NewTask(ctx, ioCreation)
+	var taskOpts []containerd.NewTaskOpts
+	if cgroup := sandbox.Config.GetLinux().GetCgroupParent(); cgroup != "" {
+		taskOpts = append(taskOpts, criopts.WithContainerdShimCgroup(cgroup))
+	}
+	task, err := container.NewTask(ctx, ioCreation, taskOpts...)
 	if err != nil {
 		return fmt.Errorf("failed to create containerd task: %v", err)
 	}


### PR DESCRIPTION
This is same as https://github.com/kubernetes-incubator/cri-containerd/pull/193 which was reverted due to failures in node-e2e on the CI. Havent been able to reproduce it locally. 

Signed-off-by: abhi <abhi@docker.com>