### PR TITLE
adding info map for verbose pod status

### DIFF
--- a/pkg/server/container_status.go
+++ b/pkg/server/container_status.go
@@ -58,7 +58,7 @@ func (c *criContainerdService) ContainerStatus(ctx context.Context, r *runtime.C
 	status := toCRIContainerStatus(container, spec, imageRef)
 	info, err := toCRIContainerInfo(ctx, container, r.GetVerbose())
 	if err != nil {
-		return nil, fmt.Errorf("failed to generate container info: %v", err)
+		return nil, fmt.Errorf("failed to get verbose container info: %v", err)
 	}
 
 	return &runtime.ContainerStatusResponse{


### PR DESCRIPTION
https://github.com/kubernetes-incubator/cri-containerd/issues/359

Commit 1: adds verbose info to pod status request
So far the additional info provided is the verbose "container" status.

There's a lot of good stuff already in the pod status response struct.

Commit 1: also adds sandboxID to the container status to allow for back tracking from the container to the pod sandbox.

Commit 2: fixes the pid reported by container status.

Signed-off-by: Mike Brown <brownwm@us.ibm.com>