### PR TITLE
Add gc.root back in vendored containerd client.

### DIFF
--- a/vendor/github.com/containerd/containerd/client.go
+++ b/vendor/github.com/containerd/containerd/client.go
@@ -238,7 +238,7 @@ func (c *Client) Pull(ctx context.Context, ref string, opts ...RemoteOpt) (Image
 		handler = images.Handlers(append(pullCtx.BaseHandlers, schema1Converter)...)
 	} else {
 		handler = images.Handlers(append(pullCtx.BaseHandlers,
-			remotes.FetchHandler(store, fetcher),
+			remotes.FetchHandler(store, fetcher, desc),
 			images.ChildrenHandler(store, platforms.Default()))...,
 		)
 	}
@@ -273,6 +273,11 @@ func (c *Client) Pull(ctx context.Context, ref string, opts ...RemoteOpt) (Image
 		imgrec = updated
 	} else {
 		imgrec = created
+	}
+
+	// Remove root tag from manifest now that image refers to it
+	if _, err := store.Update(ctx, content.Info{Digest: desc.Digest}, "labels.containerd.io/gc.root"); err != nil {
+		return nil, errors.Wrap(err, "failed to remove manifest root tag")
 	}
 
 	img := &image{

--- a/vendor/github.com/containerd/containerd/container_opts.go
+++ b/vendor/github.com/containerd/containerd/container_opts.go
@@ -2,11 +2,13 @@ package containerd
 
 import (
 	"context"
+	"time"
 
 	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/oci"
 	"github.com/containerd/containerd/platforms"
+	"github.com/containerd/containerd/snapshots"
 	"github.com/containerd/typeurl"
 	"github.com/gogo/protobuf/types"
 	"github.com/opencontainers/image-spec/identity"
@@ -93,8 +95,11 @@ func WithNewSnapshot(id string, i Image) NewContainerOpts {
 			return err
 		}
 		setSnapshotterIfEmpty(c)
+		labels := map[string]string{
+			"containerd.io/gc.root": time.Now().String(),
+		}
 		parent := identity.ChainID(diffIDs).String()
-		if _, err := client.SnapshotService(c.Snapshotter).Prepare(ctx, id, parent); err != nil {
+		if _, err := client.SnapshotService(c.Snapshotter).Prepare(ctx, id, parent, snapshots.WithLabels(labels)); err != nil {
 			return err
 		}
 		c.SnapshotKey = id
@@ -123,8 +128,11 @@ func WithNewSnapshotView(id string, i Image) NewContainerOpts {
 			return err
 		}
 		setSnapshotterIfEmpty(c)
+		labels := map[string]string{
+			"containerd.io/gc.root": time.Now().String(),
+		}
 		parent := identity.ChainID(diffIDs).String()
-		if _, err := client.SnapshotService(c.Snapshotter).View(ctx, id, parent); err != nil {
+		if _, err := client.SnapshotService(c.Snapshotter).View(ctx, id, parent, snapshots.WithLabels(labels)); err != nil {
 			return err
 		}
 		c.SnapshotKey = id

--- a/vendor/github.com/containerd/containerd/image.go
+++ b/vendor/github.com/containerd/containerd/image.go
@@ -3,6 +3,7 @@ package containerd
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/errdefs"
@@ -109,12 +110,25 @@ func (i *image) Unpack(ctx context.Context, snapshotterName string) error {
 	)
 	for _, layer := range layers {
 		labels := map[string]string{
+			"containerd.io/gc.root":      time.Now().UTC().Format(time.RFC3339),
 			"containerd.io/uncompressed": layer.Diff.Digest.String(),
 		}
+		lastUnpacked := unpacked
 
 		unpacked, err = rootfs.ApplyLayer(ctx, layer, chain, sn, a, snapshots.WithLabels(labels))
 		if err != nil {
 			return err
+		}
+
+		if lastUnpacked {
+			info := snapshots.Info{
+				Name: identity.ChainID(chain).String(),
+			}
+
+			// Remove previously created gc.root label
+			if _, err := sn.Update(ctx, info, "labels.containerd.io/gc.root"); err != nil {
+				return err
+			}
 		}
 
 		chain = append(chain, layer.Diff.Digest)
@@ -135,6 +149,15 @@ func (i *image) Unpack(ctx context.Context, snapshotterName string) error {
 			},
 		}
 		if _, err := cs.Update(ctx, cinfo, fmt.Sprintf("labels.containerd.io/gc.ref.snapshot.%s", snapshotterName)); err != nil {
+			return err
+		}
+
+		sinfo := snapshots.Info{
+			Name: rootfs,
+		}
+
+		// Config now referenced snapshot, release root reference
+		if _, err := sn.Update(ctx, sinfo, "labels.containerd.io/gc.root"); err != nil {
 			return err
 		}
 	}

--- a/vendor/github.com/containerd/containerd/remotes/docker/schema1/converter.go
+++ b/vendor/github.com/containerd/containerd/remotes/docker/schema1/converter.go
@@ -157,6 +157,7 @@ func (c *Converter) Convert(ctx context.Context) (ocispec.Descriptor, error) {
 	}
 
 	labels := map[string]string{}
+	labels["containerd.io/gc.root"] = time.Now().UTC().Format(time.RFC3339)
 	labels["containerd.io/gc.ref.content.0"] = manifest.Config.Digest.String()
 	for i, ch := range manifest.Layers {
 		labels[fmt.Sprintf("containerd.io/gc.ref.content.%d", i+1)] = ch.Digest.String()
@@ -170,6 +171,12 @@ func (c *Converter) Convert(ctx context.Context) (ocispec.Descriptor, error) {
 	ref = remotes.MakeRefKey(ctx, config)
 	if err := content.WriteBlob(ctx, c.contentStore, ref, bytes.NewReader(b), config.Size, config.Digest); err != nil {
 		return ocispec.Descriptor{}, errors.Wrap(err, "failed to write config")
+	}
+
+	for _, ch := range manifest.Layers {
+		if _, err := c.contentStore.Update(ctx, content.Info{Digest: ch.Digest}, "labels.containerd.io/gc.root"); err != nil {
+			return ocispec.Descriptor{}, errors.Wrap(err, "failed to remove blob root tag")
+		}
 	}
 
 	return desc, nil
@@ -280,8 +287,10 @@ tryit:
 
 		eg.Go(func() error {
 			defer pw.Close()
-
-			return content.Copy(ctx, cw, io.TeeReader(rc, pw), size, desc.Digest)
+			opt := content.WithLabels(map[string]string{
+				"containerd.io/gc.root": time.Now().UTC().Format(time.RFC3339),
+			})
+			return content.Copy(ctx, cw, io.TeeReader(rc, pw), size, desc.Digest, opt)
 		})
 
 		if err := eg.Wait(); err != nil {

--- a/vendor/github.com/containerd/containerd/remotes/handlers.go
+++ b/vendor/github.com/containerd/containerd/remotes/handlers.go
@@ -45,7 +45,7 @@ func MakeRefKey(ctx context.Context, desc ocispec.Descriptor) string {
 // FetchHandler returns a handler that will fetch all content into the ingester
 // discovered in a call to Dispatch. Use with ChildrenHandler to do a full
 // recursive fetch.
-func FetchHandler(ingester content.Ingester, fetcher Fetcher) images.HandlerFunc {
+func FetchHandler(ingester content.Ingester, fetcher Fetcher, root ocispec.Descriptor) images.HandlerFunc {
 	return func(ctx context.Context, desc ocispec.Descriptor) (subdescs []ocispec.Descriptor, err error) {
 		ctx = log.WithLogger(ctx, log.G(ctx).WithFields(logrus.Fields{
 			"digest":    desc.Digest,
@@ -57,13 +57,13 @@ func FetchHandler(ingester content.Ingester, fetcher Fetcher) images.HandlerFunc
 		case images.MediaTypeDockerSchema1Manifest:
 			return nil, fmt.Errorf("%v not supported", desc.MediaType)
 		default:
-			err := fetch(ctx, ingester, fetcher, desc)
+			err := fetch(ctx, ingester, fetcher, desc, desc.Digest == root.Digest)
 			return nil, err
 		}
 	}
 }
 
-func fetch(ctx context.Context, ingester content.Ingester, fetcher Fetcher, desc ocispec.Descriptor) error {
+func fetch(ctx context.Context, ingester content.Ingester, fetcher Fetcher, desc ocispec.Descriptor, root bool) error {
 	log.G(ctx).Debug("fetch")
 
 	var (
@@ -105,13 +105,13 @@ func fetch(ctx context.Context, ingester content.Ingester, fetcher Fetcher, desc
 	}
 	defer rc.Close()
 
-	r, opts := commitOpts(desc, rc)
+	r, opts := commitOpts(desc, rc, root)
 	return content.Copy(ctx, cw, r, desc.Size, desc.Digest, opts...)
 }
 
 // commitOpts gets the appropriate content options to alter
 // the content info on commit based on media type.
-func commitOpts(desc ocispec.Descriptor, r io.Reader) (io.Reader, []content.Opt) {
+func commitOpts(desc ocispec.Descriptor, r io.Reader, root bool) (io.Reader, []content.Opt) {
 	var childrenF func(r io.Reader) ([]ocispec.Descriptor, error)
 
 	switch desc.MediaType {
@@ -163,9 +163,12 @@ func commitOpts(desc ocispec.Descriptor, r io.Reader) (io.Reader, []content.Opt)
 			return errors.Wrap(err, "unable to get commit labels")
 		}
 
-		if len(children) > 0 {
+		if len(children) > 0 || root {
 			if info.Labels == nil {
 				info.Labels = map[string]string{}
+			}
+			if root {
+				info.Labels["containerd.io/gc.root"] = time.Now().UTC().Format(time.RFC3339)
 			}
 			for i, ch := range children {
 				info.Labels[fmt.Sprintf("containerd.io/gc.ref.content.%d", i)] = ch.Digest.String()


### PR DESCRIPTION
For https://github.com/containerd/containerd/issues/1785.

This PR partially revert https://github.com/containerd/containerd/pull/1690 in vendored containerd client.

Note that:
1. Image load logic is not changed, because that never fails in test.
2. A check point related `gc.root` is not added because that is on server side which we are not vendoring. However, we don't use checkpoint anyway.

If after this, the test failure never happens again, we may want to keep this until containerd side is fixed.
If after this, the test still fails, we should revert this PR immediately.

Signed-off-by: Lantao Liu <lantaol@google.com>