### PR TITLE
Move shim cgroup opts to pkg/containerd/opts.

### DIFF
--- a/pkg/containerd/opts/task.go
+++ b/pkg/containerd/opts/task.go
@@ -1,3 +1,16 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package opts
 
 import (

--- a/pkg/server/container_start.go
+++ b/pkg/server/container_start.go
@@ -27,7 +27,7 @@ import (
 	"golang.org/x/net/context"
 	"k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
 
-	criopts "github.com/kubernetes-incubator/cri-containerd/pkg/opts"
+	customopts "github.com/kubernetes-incubator/cri-containerd/pkg/containerd/opts"
 	cio "github.com/kubernetes-incubator/cri-containerd/pkg/server/io"
 	containerstore "github.com/kubernetes-incubator/cri-containerd/pkg/store/container"
 )
@@ -129,7 +129,7 @@ func (c *criContainerdService) startContainer(ctx context.Context,
 
 	var taskOpts []containerd.NewTaskOpts
 	if cgroup := sandbox.Config.GetLinux().GetCgroupParent(); cgroup != "" {
-		taskOpts = append(taskOpts, criopts.WithContainerdShimCgroup(cgroup))
+		taskOpts = append(taskOpts, customopts.WithContainerdShimCgroup(cgroup))
 	}
 	task, err := container.NewTask(ctx, ioCreation, taskOpts...)
 	if err != nil {

--- a/pkg/server/sandbox_run.go
+++ b/pkg/server/sandbox_run.go
@@ -36,7 +36,6 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
 
 	customopts "github.com/kubernetes-incubator/cri-containerd/pkg/containerd/opts"
-	criopts "github.com/kubernetes-incubator/cri-containerd/pkg/opts"
 	sandboxstore "github.com/kubernetes-incubator/cri-containerd/pkg/store/sandbox"
 	"github.com/kubernetes-incubator/cri-containerd/pkg/util"
 )
@@ -208,7 +207,7 @@ func (c *criContainerdService) RunPodSandbox(ctx context.Context, r *runtime.Run
 	// We don't need stdio for sandbox container.
 	var taskOpts []containerd.NewTaskOpts
 	if cgroup := config.GetLinux().GetCgroupParent(); cgroup != "" {
-		taskOpts = append(taskOpts, criopts.WithContainerdShimCgroup(cgroup))
+		taskOpts = append(taskOpts, customopts.WithContainerdShimCgroup(cgroup))
 	}
 	task, err := container.NewTask(ctx, containerdio.NullIO, taskOpts...)
 	if err != nil {


### PR DESCRIPTION
Custom options are moved to `pkg/containerd/opts` now.
And we need boilerplate.

Signed-off-by: Lantao Liu <lantaol@google.com>