### PR TITLE
adding verify back

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ install:
     - docker run --rm -v /usr/local/bin:/target jpetazzo/nsenter
     # Pull request test doesn't need google cloud sdk.
     - if [ "$TRAVIS_PULL_REQUEST" = "false" ] && [ ! -d ${HOME}/google-cloud-sdk ]; then
-        rm -rf "${HOME}/google-cloud-sdk"; 
+        rm -rf "${HOME}/google-cloud-sdk";
         export CLOUDSDK_CORE_DISABLE_PROMPTS=1;
         curl https://sdk.cloud.google.com | bash;
         gcloud version;
@@ -55,6 +55,12 @@ jobs:
         - make .gitvalidation
         - make binaries
       go: tip
+    - script:
+        - make install.tools
+        - make .gitvalidation
+        - make binaries
+        - make verify
+      go: 1.8.x
     - stage: Test
       script:
         - make install.deps


### PR DESCRIPTION
Adding verify back. Since we we're having intermittent travis errors for verify with go 1.9, I put it in under a 1.8.x in the build stage which will run in parallel with the 1.9 and tip build tests.

Signed-off-by: Mike Brown <brownwm@us.ibm.com>