### PR TITLE
Use one big info struct before we change info to an array.

### DIFF
--- a/pkg/server/container_status_test.go
+++ b/pkg/server/container_status_test.go
@@ -153,9 +153,10 @@ func TestToCRIContainerInfo(t *testing.T) {
 	)
 	assert.NoError(t, err)
 
-	info := toCRIContainerInfo(context.Background(),
+	info, err := toCRIContainerInfo(context.Background(),
 		container,
 		false)
+	assert.NoError(t, err)
 	assert.Nil(t, info)
 }
 


### PR DESCRIPTION
Related to https://github.com/kubernetes-incubator/cri-containerd/issues/472.
Currently `map` doesn't preserve order. Use a big struct to enforce the field order.

@mikebrow PTAL. If this makes sense, we should apply the same behavior to the other status functions.

Signed-off-by: Lantao Liu <lantaol@google.com>