### PR TITLE
Add OS and arch in release tarball.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 GO := go
+GOOS := $(shell $(GO) env GOOS)
+GOARCH := $(shell $(GO) env GOARCH)
 EPOCH_TEST_COMMIT := f9e02affccd51702191e5312665a16045ffef8ab
 PROJECT := github.com/kubernetes-incubator/cri-containerd
 BINDIR := ${DESTDIR}/usr/local/bin
@@ -24,7 +26,7 @@ VERSION := $(shell git describe --tags --dirty)
 # strip the first char of the tag if it's a `v`
 VERSION := $(VERSION:v%=%)
 TARBALL_PREFIX := cri-containerd
-TARBALL := $(TARBALL_PREFIX)-$(VERSION).tar.gz
+TARBALL := $(TARBALL_PREFIX)-$(VERSION).$(GOOS)-$(GOARCH).tar.gz
 BUILD_TAGS := seccomp apparmor
 GO_LDFLAGS := -X $(PROJECT)/pkg/version.CRIContainerdVersion=$(VERSION)
 SOURCES := $(shell find cmd/ pkg/ vendor/ -name '*.go')
@@ -79,13 +81,13 @@ $(BUILD_DIR)/cri-containerd: $(SOURCES)
 		$(PROJECT)/cmd/cri-containerd
 
 test:
-	go test -timeout=10m -race ./pkg/... \
+	$(GO) test -timeout=10m -race ./pkg/... \
 		-tags '$(BUILD_TAGS)' \
 	        -ldflags '$(GO_LDFLAGS)' \
 		-gcflags '$(GO_GCFLAGS)'
 
 $(BUILD_DIR)/integration.test: $(INTEGRATION_SOURCES)
-	go test -c $(PROJECT)/integration -o $(BUILD_DIR)/integration.test
+	$(GO) test -c $(PROJECT)/integration -o $(BUILD_DIR)/integration.test
 
 test-integration: $(BUILD_DIR)/integration.test binaries
 	@./hack/test-integration.sh
@@ -141,10 +143,10 @@ endif
 install.tools: .install.gitvalidation .install.gometalinter
 
 .install.gitvalidation:
-	go get -u github.com/vbatts/git-validation
+	$(GO) get -u github.com/vbatts/git-validation
 
 .install.gometalinter:
-	go get -u github.com/alecthomas/gometalinter
+	$(GO) get -u github.com/alecthomas/gometalinter
 	gometalinter --install
 
 .PHONY: \

--- a/cluster/gce/configure.sh
+++ b/cluster/gce/configure.sh
@@ -53,7 +53,7 @@ if [ -z "${VERSION}" ]; then
 fi
 
 # TARBALL_GCS_PATH is the path to download cri-containerd tarball for node e2e.
-TARBALL_GCS_PATH="https://storage.googleapis.com/${DEPLOY_PATH}/${PKG_PREFIX}-${VERSION}.tar.gz"
+TARBALL_GCS_PATH="https://storage.googleapis.com/${DEPLOY_PATH}/${PKG_PREFIX}-${VERSION}.linux-amd64.tar.gz"
 # TARBALL is the name of the tarball after being downloaded.
 TARBALL="cri-containerd.tar.gz"
 

--- a/contrib/ansible/tasks/binaries.yaml
+++ b/contrib/ansible/tasks/binaries.yaml
@@ -1,7 +1,7 @@
 ---
 - name: "Get Containerd and CRI-Containerd"
   unarchive:
-    src: "https://storage.googleapis.com/cri-containerd-release/cri-containerd-{{ cri_containerd_release_version }}.tar.gz"
+    src: "https://storage.googleapis.com/cri-containerd-release/cri-containerd-{{ cri_containerd_release_version }}.linux-amd64.tar.gz"
     dest: "/"
     remote_src: yes
 

--- a/contrib/ansible/vars/vars.yaml
+++ b/contrib/ansible/vars/vars.yaml
@@ -1,5 +1,5 @@
 ---
-cri_containerd_release_version: 1.0.0-alpha.1
+cri_containerd_release_version: 1.0.0-beta.0
 cri_release_directory: /opt/cri-containerd/
 local_bin_dir: /usr/local/bin/
 local_sbin_dir: /usr/local/sbin/

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -9,13 +9,24 @@ For each release, we'll publish a release tarball. The release tarball contains 
 ### Content
 As shown below, the release tarball contains:
 1) `cri-containerd`: cri-containerd binary.
-2) `containerd`, `containerd-shim`, `containerd-stress`, `ctr`: binaries for containerd.
+2) `containerd`, `containerd-shim`, `containerd-stress`, `containerd-release`, `ctr`: binaries for containerd.
 3) `runc`: runc binary.
 4) `crictl`: command line tools for CRI container runtime.
 5) `containerd.service`, `cri-containerd.service`: Systemd units for cri-containerd and containerd.
+6) `/opt/cri-containerd/cluster/`: scripts for `kube-up.sh`.
 ```console
-$ tar -tf cri-containerd-1.0.0-alpha.0.tar.gz 
+$ tar -tf cri-containerd-1.0.0-beta.0.linux-amd64.tar.gz
 ./
+./opt/
+./opt/cri-containerd/
+./opt/cri-containerd/cluster/
+./opt/cri-containerd/cluster/gce/
+./opt/cri-containerd/cluster/gce/cloud-init/
+./opt/cri-containerd/cluster/gce/cloud-init/node.yaml
+./opt/cri-containerd/cluster/gce/cloud-init/master.yaml
+./opt/cri-containerd/cluster/gce/configure.sh
+./opt/cri-containerd/cluster/health-monitor.sh
+./opt/cri-containerd/cluster/env
 ./usr/
 ./usr/local/
 ./usr/local/sbin/
@@ -24,6 +35,8 @@ $ tar -tf cri-containerd-1.0.0-alpha.0.tar.gz
 ./usr/local/bin/crictl
 ./usr/local/bin/containerd
 ./usr/local/bin/containerd-stress
+./usr/local/bin/critest
+./usr/local/bin/containerd-release
 ./usr/local/bin/containerd-shim
 ./usr/local/bin/ctr
 ./usr/local/bin/cri-containerd
@@ -32,6 +45,7 @@ $ tar -tf cri-containerd-1.0.0-alpha.0.tar.gz
 ./etc/systemd/system/
 ./etc/systemd/system/containerd.service
 ./etc/systemd/system/cri-containerd.service
+./etc/crictl.yaml
 ```
 ### Binary Information
 Information about the binaries in the release tarball:
@@ -63,12 +77,12 @@ Note that:
 ## Step 1: Download CRI-Containerd Release Tarball
 Download release tarball for the cri-containerd version you want to install from sources listed [above](#download).
 ```console
-$ wget https://storage.googleapis.com/cri-containerd-release/cri-containerd-${VERSION}.tar.gz
+$ wget https://storage.googleapis.com/cri-containerd-release/cri-containerd-${VERSION}.linux-amd64.tar.gz
 ```
 ## Step 2: Install CRI-Containerd
 If you are using systemd, just simply unpack the tarball to the root directory:
 ```shell
-sudo tar -C / -xzf cri-containerd-${VERSION}.tar.gz
+sudo tar -C / -xzf cri-containerd-${VERSION}.linux-amd64.tar.gz
 sudo mkdir -p /opt/cni/bin/
 sudo mkdir -p /etc/cni/net.d
 sudo systemctl start containerd

--- a/hack/install-deps.sh
+++ b/hack/install-deps.sh
@@ -63,7 +63,8 @@ CONTAINERD_PKG=github.com/containerd/containerd
 CRITOOL_PKG=github.com/kubernetes-incubator/cri-tools
 
 # Create a temporary GOPATH for make install.deps.
-GOPATH=$(mktemp -d /tmp/cri-containerd-install-deps.XXXX)
+TMPGOPATH=$(mktemp -d /tmp/cri-containerd-install-deps.XXXX)
+GOPATH=${TMPGOPATH}
 
 # checkout_repo checks out specified repository
 # and switch to specified  version.
@@ -146,5 +147,6 @@ ${sudo} bash -c 'cat >'${CRICTL_CONFIG_DIR}'/crictl.yaml <<EOF
 runtime-endpoint: /var/run/cri-containerd.sock
 EOF'
 
-# Clean the tmp GOPATH dir
-${sudo} rm -r ${GOPATH}
+# Clean the tmp GOPATH dir. Use sudo because runc build generates
+# some privileged files.
+${sudo} rm -rf ${TMPGOPATH}

--- a/hack/push.sh
+++ b/hack/push.sh
@@ -34,7 +34,8 @@ LATEST=${LATEST:-"latest"}
 PUSH_VERSION=${PUSH_VERSION:-false}
 
 release_tar=${ROOT}/${BUILD_DIR}/${TARBALL}
-if [ ! -e ${release_tar} ]; then
+release_tar_checksum=${release_tar}.sha1
+if [[ ! -e ${release_tar} || ! -e ${release_tar_checksum} ]]; then
   echo "Release tarball is not built"
   exit 1
 fi
@@ -51,6 +52,7 @@ fi
 
 # TODO(random-liu): Add checksum for the tarball.
 gsutil cp ${release_tar} "gs://${DEPLOY_PATH}/"
+gsutil cp ${release_tar_checksum} "gs://${DEPLOY_PATH}/"
 echo "Release tarball is uploaded to:
   https://storage.googleapis.com/${DEPLOY_PATH}/${TARBALL}"
 

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"/..
+source $(dirname "${BASH_SOURCE[0]}")/test-utils.sh
 cd ${ROOT}
 
 # BUILD_DIR is the directory to generate release tar.
@@ -45,4 +45,8 @@ mkdir -p ${destdir}/opt/cri-containerd
 cp -r ${ROOT}/cluster ${destdir}/opt/cri-containerd
 
 # Create release tar
-tar -zcvf ${BUILD_DIR}/${TARBALL} -C ${destdir} .
+tarball=${BUILD_DIR}/${TARBALL}
+tar -zcvf ${tarball} -C ${destdir} .
+checksum=$(sha1 ${tarball})
+echo "sha1sum: ${checksum} ${tarball}"
+echo ${checksum} > ${tarball}.sha1

--- a/hack/test-utils.sh
+++ b/hack/test-utils.sh
@@ -122,3 +122,14 @@ create_ttl_bucket() {
   gsutil -m acl ch -g all:R "gs://${bucket}"
   gsutil defacl set public-read "gs://${bucket}"
 }
+
+# sha1 generates a sha1 checksum for a file.
+# Var set:
+# 1. Filename.
+sha1() {
+  if which sha1sum >/dev/null 2>&1; then
+    sha1sum "$1" | awk '{ print $1 }'
+  else
+    shasum -a1 "$1" | awk '{ print $1 }'
+  fi
+}

--- a/test/configure.sh
+++ b/test/configure.sh
@@ -61,7 +61,7 @@ fi
 VERSION=$(curl -f --ipv4 --retry 6 --retry-delay 3 --silent --show-error \
   https://storage.googleapis.com/${DEPLOY_PATH}/latest)
 # TARBALL_GCS_PATH is the path to download cri-containerd tarball for node e2e.
-TARBALL_GCS_PATH="https://storage.googleapis.com/${DEPLOY_PATH}/${PKG_PREFIX}-${VERSION}.tar.gz"
+TARBALL_GCS_PATH="https://storage.googleapis.com/${DEPLOY_PATH}/${PKG_PREFIX}-${VERSION}.linux-amd64.tar.gz"
 # TARBALL is the name of the tarball after being downloaded.
 TARBALL="cri-containerd.tar.gz"
 


### PR DESCRIPTION
This PR:
1) Add OS and arch in release tarball name.
2) Generate sha1sum for release tarball.
3) Update version to 1.0.0-beta.0 to prepare for the release.

Signed-off-by: Lantao Liu <lantaol@google.com>