### PR TITLE
Add document for kube-up.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ See [test dashboard](https://k8s-testgrid.appspot.com/sig-node-containerd)
 |:----------------------:|:------------------:|
 |     v1.0.0-alpha.x     |      1.7, 1.8      |
 |      v1.0.0-beta.x     |        1.9+        |
+## Production Quality Cluster on GCE
+For a production quality cluster on GCE brought up with `kube-up.sh` refer [here](docs/kube-up.md).
 ## Installing with Ansible and Kubeadm
 For a multi node cluster installer and bring up steps using ansible and kubeadm refer [here](contrib/ansible/README.md).
 ## Custom Installation

--- a/cluster/gce/configure.sh
+++ b/cluster/gce/configure.sh
@@ -30,7 +30,7 @@ fetch_metadata() {
   local -r key=$1
   local -r attributes="http://metadata.google.internal/computeMetadata/v1/instance/attributes"
   if curl --fail --retry 5 --retry-delay 3 --silent --show-error -H "X-Google-Metadata-Request: True" "${attributes}/" | \
-    grep -q "${key}"; then
+    grep -q "^${key}$"; then
     curl --fail --retry 5 --retry-delay 3 --silent --show-error -H "X-Google-Metadata-Request: True" \
       "${attributes}/${key}"
   fi

--- a/cluster/gce/env
+++ b/cluster/gce/env
@@ -1,13 +1,13 @@
 #!/bin/bash
-CLUSTER_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+GCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # TODO(random-liu): Upload release tarball to user's own GCS, and use it. We should
 # not let all nodes of all users download tarball from cri-containerd-release.
-export KUBE_MASTER_EXTRA_METADATA="user-data=${CLUSTER_DIR}/gce/cloud-init/master.yaml,cri-containerd-configure-sh=${CLUSTER_DIR}/gce/configure.sh"
-export KUBE_NODE_EXTRA_METADATA="user-data=${CLUSTER_DIR}/gce/cloud-init/node.yaml,cri-containerd-configure-sh=${CLUSTER_DIR}/gce/configure.sh"
-if [ -n "${VERSION}" ]; then
+export KUBE_MASTER_EXTRA_METADATA="user-data=${GCE_DIR}/cloud-init/master.yaml,cri-containerd-configure-sh=${GCE_DIR}/configure.sh"
+export KUBE_NODE_EXTRA_METADATA="user-data=${GCE_DIR}/cloud-init/node.yaml,cri-containerd-configure-sh=${GCE_DIR}/configure.sh"
+if [ -n "${CRI_CONTAINERD_VERSION}" ]; then
   version=$(mktemp /tmp/version.XXXX)
-  echo "${VERSION}" > "$version"
+  echo "${CRI_CONTAINERD_VERSION}" > "$version"
   export KUBE_MASTER_EXTRA_METADATA="${KUBE_MASTER_EXTRA_METADATA},version=${version}"
   export KUBE_NODE_EXTRA_METADATA="${KUBE_NODE_EXTRA_METADATA},version=${version}"
 fi

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -66,7 +66,7 @@ The release tarball could be downloaded from either of the following sources:
 
 ## Step 0: Install Dependent Libraries
 Install required libraries for seccomp and libapparmor.
-```shell
+```bash
 sudo apt-get update
 sudo apt-get install libseccomp2
 sudo apt-get install libapparmor
@@ -76,12 +76,18 @@ Note that:
 2) If your OS distro doesn't support AppArmor, please skip installing `libapparmor`, and AppArmor will be disabled.
 ## Step 1: Download CRI-Containerd Release Tarball
 Download release tarball for the cri-containerd version you want to install from sources listed [above](#download).
-```console
-$ wget https://storage.googleapis.com/cri-containerd-release/cri-containerd-${VERSION}.linux-amd64.tar.gz
+```bash
+wget https://storage.googleapis.com/cri-containerd-release/cri-containerd-${VERSION}.linux-amd64.tar.gz
+```
+Validate checksum of the release tarball (note that checksum is added since v1.0.0-beta.0):
+```bash
+sha1sum cri-containerd-${VERSION}.linux-amd64.tar.gz
+curl https://storage.googleapis.com/cri-containerd-release/cri-containerd-${VERSION}.linux-amd64.tar.gz.sha1
+# Compare to make sure the 2 checksums are the same.
 ```
 ## Step 2: Install CRI-Containerd
 If you are using systemd, just simply unpack the tarball to the root directory:
-```shell
+```bash
 sudo tar -C / -xzf cri-containerd-${VERSION}.linux-amd64.tar.gz
 sudo mkdir -p /opt/cni/bin/
 sudo mkdir -p /etc/cni/net.d
@@ -98,7 +104,7 @@ Create the systemd drop-in file `/etc/systemd/system/kubelet.service.d/0-cri-con
 Environment="KUBELET_EXTRA_ARGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=/var/run/cri-containerd.sock"
 ```
 And reload systemd configuration:
-```shell
+```bash
 systemctl daemon-reload
 ```
 ## Bring Up the Cluster

--- a/docs/kube-up.md
+++ b/docs/kube-up.md
@@ -1,0 +1,22 @@
+# Production Quality Cluster on GCE
+This document provides the steps to bring up a production quality cluster on GCE with [`kube-up.sh`](https://kubernetes.io/docs/getting-started-guides/gce/).
+
+## Download CRI-Containerd Release Tarball
+To download release tarball, see [step 1](./installation.md#step-1-download-cri-containerd-release-tarball) in installation.md.
+
+Unpack release tarball to any directory, using `${CRI_CONTAINERD_PATH}` to indicate the directory in the doc:
+```bash
+tar -C ${CRI_CONTAINERD_PATH} -xzf cri-containerd-${VERSION}.linux-amd64.tar.gz
+```
+## Set Environment Variables for CRI-Containerd
+Use environment variable `CRI_CONTAINERD_VERSION` to specify `cri-containerd` version. By default,
+latest version will be used.
+```bash
+. ${CRI_CONTAINERD_PATH}/cluster/gce/env
+```
+## Create Kubernetes Cluster on GCE
+Follow these instructions [here](https://kubernetes.io/docs/getting-started-guides/gce/) to create a production quality Kubernetes cluster on GCE.
+
+**Make sure the Kubernetes version you are using is v1.9 or greater:**
+* When using `https://get.k8s.io`, use the environment variable `KUBERNETES_RELEASE` to set version.
+* When using a Kubernetes release tarball, make sure to select version 1.9 or greater.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -6,23 +6,23 @@ Before sending pull requests you should at least make sure your changes have pas
 ## Code Verification
 Code verification includes lint, code formatting, boilerplate check etc.
 * Install tools used by code verification:
-```shell
+```bash
 make install.tools
 ```
 * Run code verification:
-```shell
+```bash
 make verify
 ```
 ## Unit Test
 Run all unit tests in `cri-containerd` repo.
-```shell
+```bash
 make test
 ```
 ## Integration Test
 Run all integration tests in `cri-containerd` repo.
 * [Install dependencies](../README.md#install-dependencies).
 * Run integration test:
-```shell
+```bash
 make test-integration
 ```
 ## CRI Validation Test
@@ -31,15 +31,15 @@ make test-integration
 CRI validation test makes it possible to verify CRI conformance of `cri-containerd` without setting up Kubernetes components or running Kubernetes end-to-end tests.
 * [Install dependencies](../README.md#install-dependencies).
 * Build `cri-containerd`:
-```shell
+```bash
 make
 ```
 * Run CRI validation test:
-```shell
+```bash
 make test-cri
 ```
 * Focus or skip specific CRI validation test:
-```shell
+```bash
 make test-cri FOCUS=REGEXP_TO_FOCUS SKIP=REGEXP_TO_SKIP
 ```
 [More information](https://github.com/kubernetes-incubator/cri-tools) about CRI validation test.
@@ -47,11 +47,11 @@ make test-cri FOCUS=REGEXP_TO_FOCUS SKIP=REGEXP_TO_SKIP
 [Node e2e test](https://github.com/kubernetes/community/blob/master/contributors/devel/e2e-node-tests.md) is a test framework testing Kubernetes node level functionalities such as managing pods, mounting volumes etc. It starts a local cluster with Kubelet and a few other minimum dependencies, and runs node functionality tests against the local cluster.
 * [Install dependencies](../README.md#install-dependencies).
 * Run node e2e test:
-```shell
+```bash
 make test-e2e-node
 ```
 * Focus or skip specific node e2e test:
-```shell
+```bash
 make test-e2e-node FOCUS=REGEXP_TO_FOCUS SKIP=REGEXP_TO_SKIP
 ```
 [More information](https://github.com/kubernetes/community/blob/master/contributors/devel/e2e-node-tests.md) about Kubernetes node e2e test.

--- a/test/configure.sh
+++ b/test/configure.sh
@@ -30,7 +30,7 @@ fetch_metadata() {
   local -r key=$1
   local -r attributes="http://metadata.google.internal/computeMetadata/v1/instance/attributes"
   if curl --fail --retry 5 --retry-delay 3 --silent --show-error -H "X-Google-Metadata-Request: True" "${attributes}/" | \
-    grep -q "${key}"; then
+    grep -q "^${key}$"; then
     curl --fail --retry 5 --retry-delay 3 --silent --show-error -H "X-Google-Metadata-Request: True" \
       "${attributes}/${key}"
   fi


### PR DESCRIPTION
Fixes https://github.com/kubernetes-incubator/cri-containerd/issues/289.

This PR added a document for using `kube-up.sh`.

Signed-off-by: Lantao Liu <lantaol@google.com>