### PR TITLE
Add Sandbox and Container annotatinos

### DIFF
--- a/integration/clear_containers_test.go
+++ b/integration/clear_containers_test.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClearContainersCreate(t *testing.T) {
+	t.Logf("Create a sandbox")
+	sbConfig := PodSandboxConfig("sandbox", "clearcontainer")
+	sb, err := runtimeService.RunPodSandbox(sbConfig)
+	require.NoError(t, err)
+	defer func() {
+		t.Logf("Stop the PodSandbox ")
+		assert.NoError(t, runtimeService.StopPodSandbox(sb))
+		t.Logf("Remove the PodSandbox")
+		assert.NoError(t, runtimeService.RemovePodSandbox(sb))
+	}()
+
+	t.Logf("Create a container config and run container in a pod")
+	containerConfig := ContainerConfig(
+		"container1",
+		pauseImage,
+		WithTestLabels(),
+		WithTestAnnotations(),
+	)
+	cn, err := runtimeService.CreateContainer(sb, containerConfig, sbConfig)
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, runtimeService.RemoveContainer(cn))
+	}()
+	require.NoError(t, runtimeService.StartContainer(cn))
+	defer func() {
+		assert.NoError(t, runtimeService.StopContainer(cn, 10))
+	}()
+
+}

--- a/pkg/server/container_create.go
+++ b/pkg/server/container_create.go
@@ -148,6 +148,9 @@ func (c *criContainerdService) CreateContainer(ctx context.Context, r *runtime.C
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate container %q spec: %v", id, err)
 	}
+	spec.Annotations[SandboxID] = meta.SandboxID
+	spec.Annotations[SandboxName] = meta.Name
+
 	glog.V(4).Infof("Container %q spec: %#+v", id, spew.NewFormatter(spec))
 
 	// Set snapshotter before any other options.
@@ -365,6 +368,8 @@ func (c *criContainerdService) generateContainerSpec(id string, sandboxPid uint3
 	for _, group := range supplementalGroups {
 		g.AddProcessAdditionalGid(uint32(group))
 	}
+
+	g.AddAnnotation(ContainerType, ContainerTypeContainer)
 
 	return g.Spec(), nil
 }

--- a/pkg/server/sandbox_run.go
+++ b/pkg/server/sandbox_run.go
@@ -40,6 +40,24 @@ import (
 	"github.com/kubernetes-incubator/cri-containerd/pkg/util"
 )
 
+// ContainerType values
+const (
+	// ContainerTypeSandbox represents a pod sandbox container
+	ContainerTypeSandbox = "sandbox"
+
+	// ContainerTypeContainer represents a container running within a pod
+	ContainerTypeContainer = "container"
+
+	// ContainerType is the container type (sandbox or container) annotation
+	ContainerType = "io.kubernetes.cri-o.ContainerType"
+
+	// SandboxID is the sandbox ID annotation
+	SandboxID = "io.kubernetes.cri-o.SandboxID"
+
+	// SandboxName is the sandbox name annotation
+	SandboxName = "io.kubernetes.cri-o.SandboxName"
+)
+
 func init() {
 	typeurl.Register(&sandboxstore.Metadata{},
 		"github.com/kubernetes-incubator/cri-containerd/pkg/store/sandbox", "Metadata")
@@ -127,6 +145,7 @@ func (c *criContainerdService) RunPodSandbox(ctx context.Context, r *runtime.Run
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate sandbox container spec: %v", err)
 	}
+
 	glog.V(4).Infof("Sandbox container spec: %+v", spec)
 
 	var specOpts []oci.SpecOpts
@@ -319,6 +338,10 @@ func (c *criContainerdService) generateSandboxContainerSpec(id string, config *r
 
 	g.SetLinuxResourcesCPUShares(uint64(defaultSandboxCPUshares))
 	g.SetProcessOOMScoreAdj(int(defaultSandboxOOMAdj))
+
+	g.AddAnnotation(ContainerType, ContainerTypeSandbox)
+	g.AddAnnotation(SandboxID, id)
+	g.AddAnnotation(SandboxName, config.Metadata.Name)
 
 	return g.Spec(), nil
 }

--- a/pkg/server/sandbox_stop.go
+++ b/pkg/server/sandbox_stop.go
@@ -55,6 +55,10 @@ func (c *criContainerdService) StopPodSandbox(ctx context.Context, r *runtime.St
 		}
 	}
 
+	if err := c.stopSandboxContainer(ctx, sandbox.Container); err != nil {
+		return nil, fmt.Errorf("failed to stop sandbox container %q: %v", id, err)
+	}
+
 	// Teardown network for sandbox.
 	if sandbox.NetNSPath != "" && sandbox.NetNS != nil {
 		if _, err := os.Stat(sandbox.NetNSPath); err != nil {
@@ -89,9 +93,6 @@ func (c *criContainerdService) StopPodSandbox(ctx context.Context, r *runtime.St
 		return nil, fmt.Errorf("failed to unmount sandbox files in %q: %v", sandboxRoot, err)
 	}
 
-	if err := c.stopSandboxContainer(ctx, sandbox.Container); err != nil {
-		return nil, fmt.Errorf("failed to stop sandbox container %q: %v", id, err)
-	}
 	return &runtime.StopPodSandboxResponse{}, nil
 }
 


### PR DESCRIPTION
Add OCI annotations to help Virtual Machine rutimes to know if will crate a sandbox (VM) or a container (container inside Sandbox (VM).).

 