### PR TITLE
Use sha256 instead of sha1.

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -81,8 +81,8 @@ wget https://storage.googleapis.com/cri-containerd-release/cri-containerd-${VERS
 ```
 Validate checksum of the release tarball (note that checksum is added since v1.0.0-beta.0):
 ```bash
-sha1sum cri-containerd-${VERSION}.linux-amd64.tar.gz
-curl https://storage.googleapis.com/cri-containerd-release/cri-containerd-${VERSION}.linux-amd64.tar.gz.sha1
+sha256sum cri-containerd-${VERSION}.linux-amd64.tar.gz
+curl https://storage.googleapis.com/cri-containerd-release/cri-containerd-${VERSION}.linux-amd64.tar.gz.sha256
 # Compare to make sure the 2 checksums are the same.
 ```
 ## Step 2: Install CRI-Containerd

--- a/hack/push.sh
+++ b/hack/push.sh
@@ -34,7 +34,7 @@ LATEST=${LATEST:-"latest"}
 PUSH_VERSION=${PUSH_VERSION:-false}
 
 release_tar=${ROOT}/${BUILD_DIR}/${TARBALL}
-release_tar_checksum=${release_tar}.sha1
+release_tar_checksum=${release_tar}.sha256
 if [[ ! -e ${release_tar} || ! -e ${release_tar_checksum} ]]; then
   echo "Release tarball is not built"
   exit 1

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -47,6 +47,6 @@ cp -r ${ROOT}/cluster ${destdir}/opt/cri-containerd
 # Create release tar
 tarball=${BUILD_DIR}/${TARBALL}
 tar -zcvf ${tarball} -C ${destdir} .
-checksum=$(sha1 ${tarball})
-echo "sha1sum: ${checksum} ${tarball}"
-echo ${checksum} > ${tarball}.sha1
+checksum=$(sha256 ${tarball})
+echo "sha256sum: ${checksum} ${tarball}"
+echo ${checksum} > ${tarball}.sha256

--- a/hack/test-utils.sh
+++ b/hack/test-utils.sh
@@ -123,13 +123,13 @@ create_ttl_bucket() {
   gsutil defacl set public-read "gs://${bucket}"
 }
 
-# sha1 generates a sha1 checksum for a file.
+# sha256 generates a sha256 checksum for a file.
 # Var set:
 # 1. Filename.
-sha1() {
-  if which sha1sum >/dev/null 2>&1; then
-    sha1sum "$1" | awk '{ print $1 }'
+sha256() {
+  if which sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{ print $1 }'
   else
-    shasum -a1 "$1" | awk '{ print $1 }'
+    shasum -a256 "$1" | awk '{ print $1 }'
   fi
 }


### PR DESCRIPTION
Use sha256 instead of sha1.
Signed-off-by: Lantao Liu <lantaol@google.com>