### PR TITLE
Do not error out if uuid is not found.

### DIFF
--- a/cmd/cri-containerd/options/options.go
+++ b/cmd/cri-containerd/options/options.go
@@ -96,6 +96,9 @@ type Config struct {
 	ProfilingPort string `toml:"profiling_port" json:"profilingPort,omitempty"`
 	// ProfilingAddress is address for profiling via host:port/debug/pprof/
 	ProfilingAddress string `toml:"profiling_addr" json:"profilingAddress,omitempty"`
+	// SkipImageFSUUID skips retrieving imagefs uuid.
+	// TODO(random-liu): Remove this after we find a generic way to get imagefs uuid.
+	SkipImageFSUUID bool `toml:"skip_imagefs_uuid" json:"skipImageFSUUID,omitempty"`
 }
 
 // CRIContainerdOptions contains cri-containerd command line and toml options.
@@ -158,6 +161,8 @@ func (c *CRIContainerdOptions) AddFlags(fs *pflag.FlagSet) {
 		defaults.ProfilingPort, "Profiling port for web interface host:port/debug/pprof/.")
 	fs.StringVar(&c.ProfilingAddress, "profiling-addr",
 		defaults.ProfilingAddress, "Profiling address for web interface host:port/debug/pprof/.")
+	fs.BoolVar(&c.SkipImageFSUUID, "skip-imagefs-uuid",
+		defaults.SkipImageFSUUID, "Skip retrieval of imagefs uuid. When turned on, kubelet will not be able to get imagefs capacity or perform imagefs disk eviction.")
 }
 
 // InitFlags load configurations from config file, and then overwrite with flags.
@@ -228,5 +233,6 @@ func defaultConfig() Config {
 		EnableProfiling:     true,
 		ProfilingPort:       "10011",
 		ProfilingAddress:    "127.0.0.1",
+		SkipImageFSUUID:     false,
 	}
 }

--- a/pkg/server/service.go
+++ b/pkg/server/service.go
@@ -134,12 +134,16 @@ func NewCRIContainerdService(config options.Config) (CRIContainerdService, error
 		client:             client,
 	}
 
-	imageFSPath := imageFSPath(config.ContainerdConfig.RootDir, config.ContainerdConfig.Snapshotter)
-	c.imageFSUUID, err = c.getDeviceUUID(imageFSPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get imagefs uuid of %q: %v", imageFSPath, err)
+	if !c.config.SkipImageFSUUID {
+		imageFSPath := imageFSPath(config.ContainerdConfig.RootDir, config.ContainerdConfig.Snapshotter)
+		c.imageFSUUID, err = c.getDeviceUUID(imageFSPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get imagefs uuid of %q: %v", imageFSPath, err)
+		}
+		glog.V(2).Infof("Get device uuid %q for image filesystem %q", c.imageFSUUID, imageFSPath)
+	} else {
+		glog.Warning("Skip retrieving imagefs UUID, kubelet will not be able to get imagefs capacity or perform imagefs disk eviction.")
 	}
-	glog.V(2).Infof("Get device uuid %q for image filesystem %q", c.imageFSUUID, imageFSPath)
 
 	c.netPlugin, err = ocicni.InitCNI(config.NetworkPluginConfDir, config.NetworkPluginBinDir)
 	if err != nil {


### PR DESCRIPTION
Current uuid handling logic is not perfect. Some known issues have been reported such as https://github.com/kubernetes-incubator/cri-containerd/issues/509, https://github.com/kubernetes-incubator/cri-containerd/issues/399 and https://github.com/kubernetes-incubator/cri-containerd/issues/325.

When this doesn't work, kubelet won't be able to get image filesystem capacity and usage. However, we should not keep user from trying cri-containerd out because of this.

Add a flag to skip this logic, and I'll figure out how we could make this more portable across different environments.

Signed-off-by: Lantao Liu <lantaol@google.com>