### PR TITLE
Fix install-deps

### DIFF
--- a/hack/install-deps.sh
+++ b/hack/install-deps.sh
@@ -141,7 +141,8 @@ ${sudo} make install -e DESTDIR=${CONTAINERD_DIR}
 checkout_repo ${CRITOOL_PKG} ${CRITOOL_VERSION}
 cd ${GOPATH}/src/${CRITOOL_PKG}
 make
-${sudo} make install -e BINDIR=${CRICTL_DIR}
+# make install critools require GOPATH to be set correctly.
+${sudo} make install -e BINDIR=${CRICTL_DIR} GOPATH=${GOPATH}
 ${sudo} mkdir -p ${CRICTL_CONFIG_DIR}
 ${sudo} bash -c 'cat >'${CRICTL_CONFIG_DIR}'/crictl.yaml <<EOF
 runtime-endpoint: /var/run/cri-containerd.sock


### PR DESCRIPTION
Fix install-deps.
When run `make install-deps`, `sudo` will be enabled because we need to install to `/usr/local/bin`.
However, `sudo` doesn't inherit environment variables, we need to explicitly set the temporary `GOPATH` for `make install`.

Signed-off-by: Lantao Liu <lantaol@google.com>