### PR TITLE
Refactor hack utils

### DIFF
--- a/hack/push.sh
+++ b/hack/push.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-source $(dirname "${BASH_SOURCE[0]}")/test-utils.sh
+source $(dirname "${BASH_SOURCE[0]}")/utils.sh
 
 # DEPLOY_BUCKET is the gcs bucket where the tarball should be stored in.
 DEPLOY_BUCKET=${DEPLOY_BUCKET:-"cri-containerd-staging"}

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-source $(dirname "${BASH_SOURCE[0]}")/test-utils.sh
+source $(dirname "${BASH_SOURCE[0]}")/utils.sh
 cd ${ROOT}
 
 # BUILD_DIR is the directory to generate release tar.

--- a/hack/test-utils.sh
+++ b/hack/test-utils.sh
@@ -14,8 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"/..
-. ${ROOT}/hack/versions
+source $(dirname "${BASH_SOURCE[0]}")/utils.sh
+
+source ${ROOT}/hack/versions
 # CRI_CONTAINERD_FLAGS are the extra flags to use when start cri-containerd.
 CRI_CONTAINERD_FLAGS=${CRI_CONTAINERD_FLAGS:-""}
 # RESTART_WAIT_PERIOD is the period to wait before restarting cri-containerd/containerd.
@@ -86,50 +87,4 @@ readiness_check() {
       echo "$attempt_num attempt \"$command\"! Trying again in $attempt_num seconds..."
       sleep $(( attempt_num++ ))
   done
-}
-
-# upload_logs_to_gcs uploads test logs to gcs.
-# Var set:
-# 1. Bucket: gcs bucket to upload logs.
-# 2. Dir: directory name to upload logs.
-# 3. Test Result: directory of the test result.
-upload_logs_to_gcs() {
-  local -r bucket=$1
-  local -r dir=$2
-  local -r result=$3
-  if ! gsutil ls "gs://${bucket}" > /dev/null; then
-    create_ttl_bucket ${bucket}
-  fi
-  local -r upload_log_path=${bucket}/${dir}
-  gsutil cp -r "${REPORT_DIR}" "gs://${upload_log_path}"
-  echo "Test logs are uploaed to:
-    http://gcsweb.k8s.io/gcs/${upload_log_path}/"
-}
-
-# create_ttl_bucket create a public bucket in which all objects
-# have a default TTL (30 days).
-# Var set:
-# 1. Bucket: gcs bucket name.
-create_ttl_bucket() {
-  local -r bucket=$1
-  gsutil mb "gs://${bucket}"
-  local -r bucket_rule=$(mktemp)
-  # Set 30 day TTL for logs inside the bucket.
-  echo '{"rule": [{"action": {"type": "Delete"},"condition": {"age": 30}}]}' > ${bucket_rule}
-  gsutil lifecycle set "${bucket_rule}" "gs://${bucket}"
-  rm "${bucket_rule}"
-
-  gsutil -m acl ch -g all:R "gs://${bucket}"
-  gsutil defacl set public-read "gs://${bucket}"
-}
-
-# sha256 generates a sha256 checksum for a file.
-# Var set:
-# 1. Filename.
-sha256() {
-  if which sha256sum >/dev/null 2>&1; then
-    sha256sum "$1" | awk '{ print $1 }'
-  else
-    shasum -a256 "$1" | awk '{ print $1 }'
-  fi
 }

--- a/hack/update-vendor.sh
+++ b/hack/update-vendor.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"/..
+source $(dirname "${BASH_SOURCE[0]}")/utils.sh
 cd ${ROOT}
 
 echo "Sort vendor.conf..."

--- a/hack/utils.sh
+++ b/hack/utils.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"/..
+
+# upload_logs_to_gcs uploads test logs to gcs.
+# Var set:
+# 1. Bucket: gcs bucket to upload logs.
+# 2. Dir: directory name to upload logs.
+# 3. Test Result: directory of the test result.
+upload_logs_to_gcs() {
+  local -r bucket=$1
+  local -r dir=$2
+  local -r result=$3
+  if ! gsutil ls "gs://${bucket}" > /dev/null; then
+    create_ttl_bucket ${bucket}
+  fi
+  local -r upload_log_path=${bucket}/${dir}
+  gsutil cp -r "${result}" "gs://${upload_log_path}"
+  echo "Test logs are uploaed to:
+    http://gcsweb.k8s.io/gcs/${upload_log_path}/"
+}
+
+# create_ttl_bucket create a public bucket in which all objects
+# have a default TTL (30 days).
+# Var set:
+# 1. Bucket: gcs bucket name.
+create_ttl_bucket() {
+  local -r bucket=$1
+  gsutil mb "gs://${bucket}"
+  local -r bucket_rule=$(mktemp)
+  # Set 30 day TTL for logs inside the bucket.
+  echo '{"rule": [{"action": {"type": "Delete"},"condition": {"age": 30}}]}' > ${bucket_rule}
+  gsutil lifecycle set "${bucket_rule}" "gs://${bucket}"
+  rm "${bucket_rule}"
+
+  gsutil -m acl ch -g all:R "gs://${bucket}"
+  gsutil defacl set public-read "gs://${bucket}"
+}
+
+# sha256 generates a sha256 checksum for a file.
+# Var set:
+# 1. Filename.
+sha256() {
+  if which sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{ print $1 }'
+  else
+    shasum -a256 "$1" | awk '{ print $1 }'
+  fi
+}


### PR DESCRIPTION
Based on https://github.com/kubernetes-incubator/cri-containerd/pull/521.

This is just a cleanup.

Previously, we only have a `hack/test-utils.sh`. However, some functions in test-utils.sh are not actually used by test scripts, such as `create_ttl_bucket`, `sha256`, and I'm planning to add more.

This PR create a `hack/utils.sh` for pure util functions, `hack/test-utils.sh` should only be used by test scripts.