### PR TITLE
Caching IP allocated by CNI plugin

### DIFF
--- a/pkg/server/sandbox_run.go
+++ b/pkg/server/sandbox_run.go
@@ -120,6 +120,18 @@ func (c *criContainerdService) RunPodSandbox(ctx context.Context, r *runtime.Run
 				}
 			}
 		}()
+		ip, err := c.netPlugin.GetPodNetworkStatus(podNetwork)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get network status for sandbox %q: %v", id, err)
+		}
+		// Certain VM based solutions like clear containers (Issue kubernetes-incubator/cri-containerd#524)
+		//  rely on the assumption that CRI shim will not be querying the network namespace to check the
+		// network states such as IP.
+		// In furture runtime implementation should avoid relying on CRI shim implementation details.
+		// In this case however caching the IP will add a subtle performance enhancement by avoiding
+		// calls to network namespace of the pod to query the IP of the veth interface on every
+		// SandboxStatus request.
+		sandbox.IP = ip
 	}
 
 	// Create sandbox container.

--- a/pkg/store/sandbox/sandbox.go
+++ b/pkg/store/sandbox/sandbox.go
@@ -34,6 +34,8 @@ type Sandbox struct {
 	Container containerd.Container
 	// CNI network namespace client
 	NetNS *NetNS
+	// IP of Pod if it is attached to non host network
+	IP string
 }
 
 // Store stores all sandboxes.


### PR DESCRIPTION
A Possible fix to address scenario mentioned in kubernetes-incubator/cri-containerd#524
Cache the IP allocated for pods not connected to host network and avoid fetch it on every Sandbox status request.

Signed-off-by: abhi <abhi@docker.com>