### PR TITLE
Minor cleanup on selinux test

### DIFF
--- a/pkg/server/helpers_selinux_test.go
+++ b/pkg/server/helpers_selinux_test.go
@@ -62,10 +62,11 @@ func TestInitSelinuxOpts(t *testing.T) {
 			mountLabels:  []string{"user_u:object_r:container_file_t:s0:c1,c2", "user_u:object_r:svirt_sandbox_file_t:s0:c1,c2"},
 		},
 	} {
-		t.Logf("TestCase %q", desc)
-		processLabel, mountLabel, err := initSelinuxOpts(test.selinuxOpt)
-		assert.NoError(t, err)
-		assert.Equal(t, test.processLabel, processLabel)
-		assert.Contains(t, test.mountLabels, mountLabel)
+		t.Run(desc, func(t *testing.T) {
+			processLabel, mountLabel, err := initSelinuxOpts(test.selinuxOpt)
+			assert.NoError(t, err)
+			assert.Equal(t, test.processLabel, processLabel)
+			assert.Contains(t, test.mountLabels, mountLabel)
+		})
 	}
 }

--- a/pkg/server/helpers_selinux_test.go
+++ b/pkg/server/helpers_selinux_test.go
@@ -28,7 +28,7 @@ import (
 
 func TestInitSelinuxOpts(t *testing.T) {
 	if !selinux.GetEnabled() {
-		return
+		t.Skip("selinux is not enabled")
 	}
 
 	for desc, test := range map[string]struct {


### PR DESCRIPTION
- use t.Skip() instead of return
- use t.Run() instead of t.Log() for test description